### PR TITLE
signup 리팩토링, 스타일 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,32 +20,35 @@ import TodoMy from "./components/todomy/todomy.components";
 import Detail from "./components/todotest/detail.todotest.components";
 import BuyTemplate from "./components/wishtemplate/buytemplate.components";
 import UseTemplate from "./components/wishtemplate/usetemplate.components";
+import SignUp from "./components/signup/signUp.components";
 
 function App() {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [realname, setRealname] = useState("");
-  const [emailAgree, setEmailAgree] = useState(0);
-  const [snsAgree, setSnsAgree] = useState(0);
+  // const [email, setEmail] = useState("");
+  // const [password, setPassword] = useState("");
+  // const [realname, setRealname] = useState("");
+  // const [emailAgree, setEmailAgree] = useState(0);
+  // const [snsAgree, setSnsAgree] = useState(0);
 
-  const [service1, setService1] = useState(false);
-  const [service2, setService2] = useState(false);
-  const [service3, setService3] = useState(false);
-  const [service4, setService4] = useState(false);
-  const [service5, setService5] = useState(false);
+  // const [service1, setService1] = useState(false);
+  // const [service2, setService2] = useState(false);
+  // const [service3, setService3] = useState(false);
+  // const [service4, setService4] = useState(false);
+  // const [service5, setService5] = useState(false);
 
-  const [iconStyle1, setIconStyle1] = useState("disabled");
-  const [iconStyle2, setIconStyle2] = useState("disabled");
-  const [iconStyle3, setIconStyle3] = useState("disabled");
-  const [iconStyle4, setIconStyle4] = useState("disabled");
-  const [iconStyle5, setIconStyle5] = useState("disabled");
+  // const [iconStyle1, setIconStyle1] = useState("disabled");
+  // const [iconStyle2, setIconStyle2] = useState("disabled");
+  // const [iconStyle3, setIconStyle3] = useState("disabled");
+  // const [iconStyle4, setIconStyle4] = useState("disabled");
+  // const [iconStyle5, setIconStyle5] = useState("disabled");
 
   return (
     <div id="main-container">
       <div className="App">
         <Routes>
           <Route path="/" element={<Login />} />
-          <Route
+          <Route path="/signup" element={<SignUp />} />
+
+          {/* <Route
             path="/signup1"
             element={
               <Signup1
@@ -117,7 +120,7 @@ function App() {
                 snsAgree={snsAgree}
               />
             }
-          />
+          /> */}
           <Route path="/onboard1" element={<Onboard1 />} />
           <Route path="/onboard2" element={<Onboard2 />} />
           <Route path="/onboard3" element={<Onboard3 />} />
@@ -138,6 +141,7 @@ function App() {
           <Route path="todo/detail/:id" element={<Detail />} />
           <Route path="/main/buytemplate" element={<BuyTemplate />} />
           <Route path="/main/usetemplate" element={<UseTemplate />} />
+
         </Routes>
       </div>
     </div>

--- a/src/components/login/login.components.jsx
+++ b/src/components/login/login.components.jsx
@@ -126,7 +126,7 @@ function Login() {
               fontSize: "12px",
               color: "#000000",
             }}
-            to="/signup1"
+            to="/signup"
           >
             회원가입하기
           </Link>

--- a/src/components/signup/service.components.css
+++ b/src/components/signup/service.components.css
@@ -3,3 +3,26 @@
   padding-top: 10px !important;
   padding-left: 20px !important;
 }
+
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-family: "KoreanDefault";
+  background-color: #fbfbfb;
+  position:relative;
+}
+
+.serviceDetail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  z-index: 10;
+  position: absolute;
+  top: 0;
+  background-color: white;
+  width: 100%;
+  height:100%;
+  left: 0;
+}

--- a/src/components/signup/service.components.jsx
+++ b/src/components/signup/service.components.jsx
@@ -1,236 +1,114 @@
-import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
-import { useNavigate } from "react-router-dom";
 import { useState } from "react";
-import { List, Typography, Divider, Card } from "antd";
+import { List } from "antd";
 import CheckIcon from "@mui/icons-material/Check";
 import "./service.components.css";
+import ServiceDetail from "./serviceDetail.components";
 
 function Service({
-  service1,
-  service2,
-  service3,
-  service4,
-  service5,
-  setService1,
-  setService2,
-  setService3,
-  setService4,
-  setService5,
-  iconStyle1,
-  iconStyle2,
-  iconStyle3,
-  iconStyle4,
-  iconStyle5,
-  setIconStyle1,
-  setIconStyle2,
-  setIconStyle3,
-  setIconStyle4,
-  setIconStyle5,
+  service,
+  setService,
+  emailAgree, 
   setEmailAgree,
-  setSnsAgree,
+  snsAgree, 
+  setSnsAgree
 }) {
-  let navigate = useNavigate();
-  const [check1, setCheck1] = useState(false);
-  const [check2, setCheck2] = useState(false);
+  const [showDetail, setShowDetail] = useState(false);
+
+  const iconStyle = (check) => check ? "enabled" : "disabled"
+  const serviceText = ["만 14세 이상입니다. (필수)", "서비스 이용약관 동의 (필수)", "개인정보 수집 및 이용 동의 (필수)" ];
 
   return (
     <>
-      <div className="header">
-        <ArrowBackIosIcon
-          className="back-arrow"
-          onClick={() => {
-            navigate("/signup1");
-          }}
-          style={{ marginRight: "120px", marginBottom: "10px" }}
-        />
-        <span className="title" style={{ marginRight: "20px" }}>
-          약관 동의
-        </span>
-      </div>
-      <Card style={{ width: 327, height: 48 }}>
-        <span style={{ display: "flex" }}>
-          <CheckIcon
-            onClick={() => {
-              if (iconStyle2 === "enabled") {
-                setIconStyle2("disabled");
-              } else {
-                setIconStyle2("enabled");
-              }
-              setService2(!service2);
-            }}
-            className={iconStyle2}
-          />
-          <span style={{ marginTop: "2px" }}>만 14세 이상입니다. (필수)</span>
-        </span>
-      </Card>
-      <Card style={{ width: 327, height: 170, marginTop: 9 }}>
-        <span style={{ display: "flex" }}>
-          <CheckIcon
-            className={iconStyle3}
-            onClick={() => {
-              if (iconStyle3 === "enabled") {
-                setIconStyle3("disabled");
-              } else {
-                setIconStyle3("enabled");
-              }
-              setService3(!service3);
-            }}
-          />
-          <span style={{ marginTop: "2px" }}>서비스 이용 약관 동의 (필수)</span>
-        </span>
-        <hr style={{ opacity: 0.2 }} />
-        <span>
-          <h4 style={{ fontSize: "13px", marginBottom: 5 }}>제 1조 (총칙)</h4>
-          <h5 style={{ fontSize: "11px", marginBottom: 8 }}>제 1조 (목적)</h5>
-          <p style={{ fontSize: "9px", marginTop: 4, opacity: 0.5 }}>
-            이 약관은 "마이플래닛 컴퍼니"(이하 “회사”라 함)가 운영하는
-            “마이플래닛” (이하 “마이플래닛”이라 함)에서 제공하는 모든
-            서비스(이하 “서비스”라 함) 를 이용함에 있어 이용자의 권리 및 의무,
-            기타 부수 사항에 관하여 규정함을 목적으로 합니다.
-          </p>
-        </span>
-      </Card>
-      <Card style={{ width: 327, height: 170, marginTop: 9 }}>
-        <span style={{ display: "flex" }}>
-          <CheckIcon
-            className={iconStyle4}
-            onClick={() => {
-              if (iconStyle4 === "enabled") {
-                setIconStyle4("disabled");
-              } else {
-                setIconStyle4("enabled");
-              }
-              setService4(!service4);
-            }}
-          />
-          <span style={{ marginTop: "2px" }}>
-            개인정보 수집 및 이용 동의 (필수)
-          </span>
-        </span>
-        <hr style={{ opacity: 0.2 }} />
-        <span>
-          <h4 style={{ fontSize: "13px", marginBottom: 5 }}>제 1조 (총칙)</h4>
-          <h5 style={{ fontSize: "11px", marginBottom: 8 }}>제 1조 (목적)</h5>
-          <p style={{ fontSize: "9px", marginTop: 4, opacity: 0.5 }}>
-            수집하는 개인정보 항목 (이력서 양식 내용 일체) : 성명, 주민등록번호,
-            전화번호, 주소, 이메일, 가족관계, 학력사항, 경력 사항, 자격사항 등과
-            그 외 이력서 기재 내용 일체 - 개인정보의 이용 목적 : 수집된
-            개인정보를 사업장 신규 채용 서류 심사 및 인사서 류로 활용하며, 목적
-            외의 용도로는 사용하지 않습니다.
-          </p>
-        </span>
-      </Card>
-      <Card style={{ width: 327, height: 96, marginTop: 9 }}>
-        <span style={{ display: "flex" }}>
-          <CheckIcon
-            className={iconStyle5}
-            onClick={() => {
-              if (iconStyle5 === "enabled") {
-                setIconStyle5("disabled");
-              } else {
-                setIconStyle5("enabled");
-              }
-              setService5(!service5);
-              setCheck1(!check1);
-              setCheck2(!check2);
-            }}
-          />
-          <span style={{ marginTop: "2px" }}>마케팅 정보 수신 동의 (선택)</span>
-        </span>
-        <hr style={{ opacity: 0.2 }} />
-        <span style={{ display: "flex", marginTop: 12 }}>
-          <span>
-            <div className="check" style={{ marginLeft: 20 }}>
-              {!check1 ? (
-                <img
-                  src="/images/check1.png"
-                  onClick={() => {
-                    setCheck1(!check1);
-                    setEmailAgree(1);
-                  }}
-                  style={{
-                    width: "18px",
-                    height: "18px",
-                    marginRight: "8px",
-                  }}
-                />
-              ) : (
-                <img
-                  src="/images/check2.png"
-                  onClick={() => {
-                    setCheck1(!check1);
-                    setEmailAgree(0);
-                  }}
-                  style={{
-                    width: "18px",
-                    height: "18px",
-                    marginRight: "8px",
-                  }}
-                />
-              )}
-
-              <p style={{ marginTop: 0, marginBottom: 0, color: "#C4C4C4" }}>
-                이메일 수신 동의
-              </p>
-            </div>
-          </span>
-          <span>
-            <div className="check" style={{ marginLeft: 20 }}>
-              {!check2 ? (
-                <img
-                  src="/images/check1.png"
-                  onClick={() => {
-                    setCheck2(!check2);
-                    setSnsAgree(1);
-                  }}
-                  style={{
-                    width: "18px",
-                    height: "18px",
-                    marginRight: "8px",
-                  }}
-                />
-              ) : (
-                <img
-                  src="/images/check2.png"
-                  onClick={() => {
-                    setCheck2(!check2);
-                    setSnsAgree(0);
-                  }}
-                  style={{
-                    width: "18px",
-                    height: "18px",
-                    marginRight: "8px",
-                  }}
-                />
-              )}
-
-              <p style={{ marginTop: 0, marginBottom: 0, color: "#C4C4C4" }}>
-                SNS 수신 동의
-              </p>
-            </div>
-          </span>
-        </span>
-      </Card>
-      {service2 && service3 && service4 ? (
-        <>
-          <button
-            onClick={() => {
-              navigate("/signup1");
-            }}
-            className="login-button"
+      <div className="service">
+        <p style={{ fontFamily: "PretendardMedium", fontSize: "14px", marginLeft: "10px" }}>
+          서비스 정책
+        </p>
+        <List size="small" bordered style={{borderRadius: "4px"}}>
+          <List.Item
+            className="listItem"
           >
-            닫기
-          </button>
-          <br />
-        </>
-      ) : (
-        <>
-          <button disabled className="login-button" style={{ opacity: "0.5" }}>
-            닫기
-          </button>
-          <br />
-        </>
-      )}
+            <CheckIcon
+              className={iconStyle(service[0])}
+              style={{ fontFamily: "PretendardRegular", fontSize:"19px" }}
+              onClick={() => {
+                if (service[0]) {
+                  setService([false, false, false, false, false]);
+                  setEmailAgree(false);
+                  setSnsAgree(false);
+                } else {
+                  setService([true, true, true, true, true]);
+                  setEmailAgree(true);
+                  setSnsAgree(true);
+                }
+            }}
+            />
+            <span style={{marginRight: 'auto'}}>전체 동의</span>
+          </List.Item>
+
+          {serviceText.map((text, i) => 
+            <List.Item
+              className="listItem"
+              style={{borderBottom: "none"}}
+              key={i}
+            >
+              <CheckIcon
+                className={"checkIcon "+ iconStyle(service[i + 1])}
+                style={{ fontFamily: "PretendardRegular", fontSize:"19px" }}
+                onClick={() => {
+                  setService([...service.slice(0, i + 1), !service[i + 1], ...service.slice(i + 2)]);
+                }}
+              />
+              <span style={{marginRight: 'auto'}}>{text}</span>
+              <img
+                src="/images/detail.png"
+                style={{ marginLeft: "auto", width: "6px" }}
+                onClick={() => {
+                  setShowDetail(true);
+                }}
+              />
+            </List.Item>)}
+
+          <List.Item
+            className="listItem"
+          >
+            <CheckIcon
+              className={iconStyle(service[4])}
+              style={{ fontFamily: "PretendardRegular", fontSize:"19px"}}
+              onClick={() => {
+                setService([...service.slice(0, 4), !service[4]]);
+                if (service[4]) {
+                  setEmailAgree(false);
+                  setSnsAgree(false);
+                } else {
+                  setEmailAgree(true);
+                  setSnsAgree(true);
+                }
+            }}
+            />
+            <span style={{marginRight: 'auto'}}>마케팅 수신 동의 (선택)</span>
+            <img
+                src="/images/detail.png"
+                style={{ marginLeft: "auto", width: "6px" }}
+                onClick={() => {
+                  setShowDetail(true);
+                }}
+              />
+          </List.Item>
+        </List>
+      </div>
+
+      { showDetail && 
+        <ServiceDetail 
+          setShowDetail={setShowDetail}  
+          service={service}
+          setService={setService}
+          iconStyle={iconStyle}
+          emailAgree={emailAgree}
+          setEmailAgree={setEmailAgree}
+          snsAgree={snsAgree}
+          setSnsAgree={setSnsAgree}
+        />
+      }
     </>
   );
 }

--- a/src/components/signup/serviceDetail.components.jsx
+++ b/src/components/signup/serviceDetail.components.jsx
@@ -1,0 +1,168 @@
+import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
+import { useState } from "react";
+import { Card } from "antd";
+import CheckIcon from "@mui/icons-material/Check";
+
+function ServiceDetail({ 
+    setShowDetail, 
+    setService, 
+    service, 
+    iconStyle, 
+    emailAgree, 
+    setEmailAgree, 
+    snsAgree, 
+    setSnsAgree 
+}) {
+
+  return (
+    <div className="serviceDetail">
+      <div className="header">
+        <CloseOutlinedIcon
+          className="back-arrow"
+          onClick={() => {
+            setShowDetail(false);
+          }}
+          style={{ marginRight: "120px", marginBottom: "10px" }}
+        />
+        <span className="title" style={{ marginRight: "20px" }}>
+          약관 동의
+        </span>
+      </div>
+
+      <Card style={{ width: 327, height: 48 }}>
+        <span style={{ display: "flex" }}>
+          <CheckIcon
+            className={iconStyle(service[1])}
+            onClick={() => {
+              setService([...service.slice(0, 1), !service[1], ...service.slice(2)]);
+            }}
+          />
+          <span style={{ marginTop: "2px" }}>만 14세 이상입니다. (필수)</span>
+        </span>
+      </Card>
+
+      <Card style={{ width: 327, height: 170, marginTop: 9 }}>
+        <span style={{ display: "flex" }}>
+          <CheckIcon
+            className={iconStyle(service[2])}
+            onClick={() => {
+              setService([...service.slice(0, 2), !service[2], ...service.slice(3)]);
+            }}
+          />
+          <span style={{ marginTop: "2px" }}>서비스 이용 약관 동의 (필수)</span>
+        </span>
+        <hr style={{ opacity: 0.2 }} />
+        <span>
+          <h4 style={{ fontSize: "13px", marginBottom: 5 }}>제 1조 (총칙)</h4>
+          <h5 style={{ fontSize: "11px", marginBottom: 8 }}>제 1조 (목적)</h5>
+          <p style={{ fontSize: "9px", marginTop: 4, opacity: 0.5 }}>
+            이 약관은 "마이플래닛 컴퍼니"(이하 “회사”라 함)가 운영하는
+            “마이플래닛” (이하 “마이플래닛”이라 함)에서 제공하는 모든
+            서비스(이하 “서비스”라 함) 를 이용함에 있어 이용자의 권리 및 의무,
+            기타 부수 사항에 관하여 규정함을 목적으로 합니다.
+          </p>
+        </span>
+      </Card>
+
+      <Card style={{ width: 327, height: 170, marginTop: 9 }}>
+        <span style={{ display: "flex" }}>
+          <CheckIcon
+            className={iconStyle(service[3])}
+            onClick={() => {
+              setService([...service.slice(0, 3), !service[3], ...service.slice(4)]);
+            }}
+          />
+          <span style={{ marginTop: "2px" }}>
+            개인정보 수집 및 이용 동의 (필수)
+          </span>
+        </span>
+        <hr style={{ opacity: 0.2 }} />
+        <span>
+          <h4 style={{ fontSize: "13px", marginBottom: 5 }}>제 1조 (총칙)</h4>
+          <h5 style={{ fontSize: "11px", marginBottom: 8 }}>제 1조 (목적)</h5>
+          <p style={{ fontSize: "9px", marginTop: 4, opacity: 0.5 }}>
+            수집하는 개인정보 항목 (이력서 양식 내용 일체) : 성명, 주민등록번호,
+            전화번호, 주소, 이메일, 가족관계, 학력사항, 경력 사항, 자격사항 등과
+            그 외 이력서 기재 내용 일체 - 개인정보의 이용 목적 : 수집된
+            개인정보를 사업장 신규 채용 서류 심사 및 인사서 류로 활용하며, 목적
+            외의 용도로는 사용하지 않습니다.
+          </p>
+        </span>
+      </Card>
+
+      <Card style={{ width: 327, height: 96, marginTop: 9 }}>
+        <span style={{ display: "flex" }}>
+          <CheckIcon
+            className={iconStyle(service[4])}
+            onClick={() => {
+              setService([...service.slice(0, 4), !service[4], ...service.slice(5)]);
+              if (service[4]) {
+                setEmailAgree(false);
+                setSnsAgree(false);
+              } else {
+                setEmailAgree(true);
+                setSnsAgree(true);
+              }
+            }}
+          />
+          <span style={{ marginTop: "2px" }}>마케팅 정보 수신 동의 (선택)</span>
+        </span>
+
+        <hr style={{ opacity: 0.2 }} />
+
+        <span style={{ display: "flex", marginTop: 12 }}>
+          <span>
+            <div className="check" style={{ marginLeft: 20 }}>
+              <img
+                src={ emailAgree? "/images/check2.png": "/images/check1.png" }
+                onClick={() => {
+                  setEmailAgree(!emailAgree);
+                }}
+                style={{
+                  width: "18px",
+                  height: "18px",
+                  marginRight: "8px",
+                }}
+              />
+
+              <p style={{ marginTop: 0, marginBottom: 0, color: "#C4C4C4" }}>
+                이메일 수신 동의
+              </p>
+            </div>
+          </span>
+
+          <span>
+            <div className="check" style={{ marginLeft: 20 }}>
+                <img
+                    src={ snsAgree? "/images/check2.png": "/images/check1.png" }
+                    onClick={() => {
+                        setSnsAgree(!snsAgree);
+                    }}
+                    style={{
+                        width: "18px",
+                        height: "18px",
+                        marginRight: "8px",
+                    }}
+                    />
+
+                    <p style={{ marginTop: 0, marginBottom: 0, color: "#C4C4C4" }}>
+                    SNS 수신 동의
+                    </p>
+            </div>
+          </span>
+        </span>
+      </Card>
+
+      <button
+        onClick={() => setShowDetail(false)}
+        className="login-button"
+      >
+        닫기
+      </button>
+      <br />
+
+    </div>
+  )
+}
+
+export default ServiceDetail

--- a/src/components/signup/signUp.components.jsx
+++ b/src/components/signup/signUp.components.jsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
+import Signup1 from "./signup1.components";
+import Signup2 from './signup2.components';
+
+
+function SignUp() {
+    let navigate = useNavigate();
+    const [step, setStep] = useState(1);
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
+    const [equalPw, setEqualPw] = useState("");
+    const [name, setName] = useState("");
+    const [emailCheck, setEmailCheck] = useState(false);
+    const [pwCheck, setPwCheck] = useState(false)
+    const [nameCheck, setNameCheck] = useState(false);
+    const [service, setService] = useState([false, false, false, false, false]);
+    const [emailAgree, setEmailAgree] = useState(false);
+    const [snsAgree, setSnsAgree] = useState(false)
+
+    const prop = { email, setEmail, password, setPassword, equalPw, setEqualPw, name, setName, emailCheck, setEmailCheck, pwCheck, setPwCheck, nameCheck, setNameCheck, service, setService, setStep, emailAgree, setEmailAgree, snsAgree, setSnsAgree }
+
+    return (
+        <div className="container">
+            <div className="header">
+                <ArrowBackIosIcon
+                    className="back-arrow"
+                    onClick={() => {
+                        step === 1 ? 
+                        navigate("/") :
+                        setStep(1)
+                    }}
+                />
+                <span className="title">회원가입 ({step}/2)</span>
+            </div>
+            { step === 1 ?
+                <Signup1 { ...prop } /> :
+                <Signup2 { ...prop } />
+            }
+        </div>
+    );
+}
+
+export default SignUp

--- a/src/components/signup/signup1.components.css
+++ b/src/components/signup/signup1.components.css
@@ -21,6 +21,7 @@
 .disabled {
   margin-right: 10px;
   opacity: 0.5;
+  color: #CECECE;
 }
 #inputID::placeholder{
   font-size: 14px;
@@ -29,4 +30,31 @@
 #inputID{
   border-color: #EDEDED;
   border-width: 1px;
+}
+
+.listItem {
+  display: "flex";
+  justify-content: "flex-start";
+  margin-bottom: 0;
+}
+
+.listItem:last-child, .listItem:first-child {
+  margin-bottom: 10px;
+}
+
+.inputLabel {
+  margin-bottom: 8px;
+  margin-left: 10px;
+  font-family: "PretendardMedium";
+  font-size: 14px;
+}
+
+.inputText {
+  width: 327px;
+  height: 44px;
+  margin-bottom: 5px;
+  border-radius: 4px;
+  border-color: #EDEDED;
+  font-family: "PretendardRegular";
+  font-size: 14px;
 }

--- a/src/components/signup/signup1.components.jsx
+++ b/src/components/signup/signup1.components.jsx
@@ -1,228 +1,170 @@
 import { useState } from "react";
 import "./signup1.components.css";
-import { Button } from "@nextui-org/react";
-import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
-import CheckIcon from "@mui/icons-material/Check";
-import { Input, Switch } from "antd";
-import { List, Typography, Divider } from "antd";
-import { useNavigate } from "react-router-dom";
+import { Input } from "antd";
 import validator from "validator";
-import { height } from "@mui/system";
+import Visibility from "./visibility.conponents";
+import Service from './service.components';
 
 function Signup1({
-  setEmailSignup,
+  email,
+  setEmail,
+  password,
   setPassword,
-  setRealname,
-  setPhoneNum,
+  name,
+  setName,
+  equalPw,
+  setEqualPw,
+  setStep,
+  emailCheck,
+  setEmailCheck,
+  pwCheck,
+  setPwCheck,
+  nameCheck,
+  setNameCheck,
+  service,
+  setService,
+  emailAgree,
   setEmailAgree,
+  snsAgree,
   setSnsAgree,
-  service1,
-  service2,
-  service3,
-  service4,
-  service5,
-  setService1,
-  setService2,
-  setService3,
-  setService4,
-  setService5,
-  iconStyle1,
-  iconStyle2,
-  iconStyle3,
-  iconStyle4,
-  iconStyle5,
-  setIconStyle1,
-  setIconStyle2,
-  setIconStyle3,
-  setIconStyle4,
-  setIconStyle5,
 }) {
-  let navigate = useNavigate();
-  let passwordValidator = require("password-validator");
+  const [visible, setVisible] = useState(false);
+  const passwordValidator = require("password-validator");
   let schema = new passwordValidator();
   schema.is().min(8).has().digits(1);
 
-  const [email, setEmail] = useState("");
-  const [pw, setPw] = useState(" ");
-  const [equalPw, setEqualPw] = useState("");
-  const [name, setName] = useState("");
-
-  const [emailCheck, setEmailCheck] = useState(null);
-  const [pwCheck, setPwCheck] = useState(null);
-  const [nameCheck, setNameCheck] = useState(null);
+  const canGoNext = nameCheck &&
+  emailCheck &&
+  equalPw == password &&
+  pwCheck &&
+  service[1] &&
+  service[2] &&
+  service[3];
 
   const validateEmail = (e) => {
-    let email = e.target.value;
+    const email = e.target.value;
+    setEmail(email);
+
     if (validator.isEmail(email)) {
       setEmailCheck(true);
-      setEmail(email);
-      setEmailSignup(email);
     } else {
       setEmailCheck(false);
     }
   };
+
   const validatePassword = (e) => {
-    let pw = e.target.value;
+    const pw = e.target.value;
+    setPassword(pw);
 
     if (schema.validate(pw)) {
       setPwCheck(true);
-      setPw(pw);
-      setPassword(pw);
     } else {
       setPwCheck(false);
     }
   };
 
+  const checkIcon = (check) => check ? (
+    <img src="/images/greentick.png" style={{ width: "18px" }} />
+  ) : (
+    <span />
+  )
+
   return (
     <>
-      <div className="header">
-        <ArrowBackIosIcon
-          className="back-arrow"
-          onClick={() => {
-            navigate("/");
-          }}
-        />
-        <span className="title">회원가입 (1/2)</span>
-      </div>
       <div className="main">
         <div className="id-input">
-          <p
-            style={{
-              marginBottom: "8px",
-              marginLeft: "10px",
-              fontFamily: "PretendardMedium",
-              fontSize: "14px",
-            }}
-          >
+          <p className="inputLabel">
             아이디 (이메일)
           </p>
           <Input
             id="inputID"
-            style={{ fontFamily: "PretendardRegular", fontSize: "14px" }}
-            className="email-input"
+            className="email-input inputText"
             size="large"
             placeholder="자주 사용하는 이메일 입력"
+            value={email}
             onChange={(e) => validateEmail(e)}
-            suffix={
-              emailCheck ? (
-                <img src="/images/greentick.png" style={{ width: "18px" }} />
-              ) : (
-                <span />
-              )
-            }
-            style={{
-              width: "327px",
-              marginBottom: "5px",
-              borderColor: "#EDEDED",
-            }}
+            suffix={ checkIcon(emailCheck) }
           />
         </div>
         <div className="pw-input">
-          <p
-            style={{
-              marginBottom: "8px",
-              marginLeft: "10px",
-              fontFamily: "PretendardMedium",
-              fontSize: "14px",
-            }}
-          >
+          <p className="inputLabel">
             비밀번호
           </p>
           <Input
             id="inputID"
-            type="password"
-            className="password-input"
+            className="password-input inputText"
+            type={visible? "text" : "password"}
             size="large"
-            onChange={(e) => {
-              validatePassword(e);
-            }}
+            value={password}
+            onChange={(e) => validatePassword(e)}
             suffix={
-              pwCheck ? (
-                <img src="/images/greentick.png" style={{ width: "18px" }} />
-              ) : (
-                <span />
-              )
+              <>
+                { checkIcon(pwCheck) }
+                <Visibility visible={visible} setVisible={setVisible} />
+              </>
             }
             placeholder="영문, 숫자, 특수문자 포함 8자 이상"
-            style={{
-              width: "327px",
-              marginBottom: "5px",
-              borderColor: "#EDEDED",
-            }}
           />
         </div>
         <div className="pw-check">
-          <p
-            style={{
-              marginBottom: "8px",
-              marginLeft: "10px",
-              fontFamily: "PretendardMedium",
-              fontSize: "14px",
-            }}
-          >
+          <p className="inputLabel">
             비밀번호 확인
           </p>
           <Input
             id="inputID"
             type="password"
-            className="password-check"
+            className="password-check inputText"
             size="large"
             placeholder="입력한 비밀번호와 일치하는지 확인"
-            onChange={(e) => {
-              setEqualPw(e.target.value);
-            }}
-            suffix={
-              equalPw === pw ? (
-                <img src="/images/greentick.png" style={{ width: "18px" }} />
-              ) : (
-                <span />
-              )
-            }
-            style={{
-              width: "327px",
-              marginBottom: "5px",
-              borderRadius: "5px",
-              borderColor: "#EDEDED",
-            }}
+            value={equalPw}
+            onChange={(e) => setEqualPw(e.target.value)}
+            suffix={checkIcon(equalPw === password && equalPw.length > 0)}
           />
         </div>
         <div className="nm-input">
-          <p
-            style={{
-              marginBottom: "8px",
-              marginLeft: "10px",
-              fontFamily: "PretendardMedium",
-              fontSize: "14px",
-            }}
-          >
+          <p className="inputLabel">
             이름
           </p>
           <Input
             id="inputID"
-            className="name-input"
+            className="name-input inputText"
             size="large"
             placeholder="실명 입력"
+            value={name}
             onChange={(e) => {
               setName(e.target.value);
-              setRealname(e.target.value);
               setNameCheck(true);
             }}
-            suffix={
-              name ? (
-                <img src="/images/greentick.png" style={{ width: "18px" }} />
-              ) : (
-                <span />
-              )
-            }
-            style={{
-              width: "327px",
-              marginBottom: "12px",
-              borderRadius: "5px",
-              borderColor: "#EDEDED",
-            }}
+            suffix={checkIcon(nameCheck)}
           />
         </div>
-        {/* <div className="num-input">
+
+        <Service 
+          service={service} 
+          setService={setService} 
+          emailAgree={emailAgree}
+          setEmailAgree={setEmailAgree}
+          snsAgree={snsAgree}
+          setSnsAgree={setSnsAgree}
+        />
+        
+        <button
+          disabled={!canGoNext}
+          className="login-button"
+          style={{ opacity: canGoNext? "1": "0.5"}}
+          onClick={() => setStep(2)}
+        >
+          다음
+        </button>
+        <br />
+      </div>
+    </>
+  );
+}
+
+export default Signup1;
+
+/* <div className="num-input">
           <p style={{ marginLeft: "10px" }}>휴대폰 번호</p>
           <div style={{ display: "flex" }}>
             <Input
@@ -252,165 +194,4 @@ function Signup1({
               borderRadius: "5px",
             }}
           />
-        </div> */}
-        <div className="service">
-          <p style={{ fontFamily: "PretendardMedium", fontSize: "14px" }}>
-            서비스 정책
-          </p>
-          <List size="small" bordered>
-            <List.Item
-              style={{ display: "flex", justifyContent: "flex-start" }}
-            >
-              <CheckIcon
-                className={iconStyle1}
-                style={{ fontFamily: "PretendardMedium", fontSize: "14px" }}
-                onClick={() => {
-                  if (iconStyle1 === "enabled") {
-                    setIconStyle1("disabled");
-                    setIconStyle2("disabled");
-                    setIconStyle4("disabled");
-                    setIconStyle5("disabled");
-                    setIconStyle3("disabled");
-                  } else {
-                    setIconStyle1("enabled");
-                    setIconStyle2("enabled");
-                    setIconStyle3("enabled");
-                    setIconStyle4("enabled");
-                    setIconStyle5("enabled");
-                  }
-                  setService1(true);
-                  setService2(true);
-                  setService3(true);
-                  setService4(true);
-                  setService5(true);
-                }}
-              />
-              전체 동의
-            </List.Item>
-            <List.Item
-              style={{ display: "flex", justifyContent: "flex-start" }}
-            >
-              <CheckIcon
-                style={{ fontFamily: "PretendardRegular", fontSize: "14px" }}
-                className={iconStyle2}
-                onClick={() => {
-                  if (iconStyle2 === "enabled") {
-                    setIconStyle2("disabled");
-                  } else {
-                    setIconStyle2("enabled");
-                  }
-                  setService2(true);
-                }}
-              />
-              만 14세 이상입니다. (필수)
-            </List.Item>
-            <List.Item
-              style={{ display: "flex", justifyContent: "flex-start" }}
-            >
-              <CheckIcon
-                className={iconStyle3}
-                style={{ fontFamily: "PretendardRegular", fontSize: "14px" }}
-                onClick={() => {
-                  if (iconStyle3 === "enabled") {
-                    setIconStyle3("disabled");
-                  } else {
-                    setIconStyle3("enabled");
-                  }
-                  setService3(true);
-                }}
-              />
-              서비스 이용약관 동의 (필수)
-              <img
-                src="/images/detail.png"
-                style={{ marginLeft: "auto", width: "6px" }}
-                onClick={() => {
-                  navigate("/service");
-                }}
-              />
-            </List.Item>
-            <List.Item
-              style={{ display: "flex", justifyContent: "flex-start" }}
-            >
-              <CheckIcon
-                className={iconStyle4}
-                style={{ fontFamily: "PretendardRegular", fontSize: "14px" }}
-                onClick={() => {
-                  if (iconStyle4 === "enabled") {
-                    setIconStyle4("disabled");
-                  } else {
-                    setIconStyle4("enabled");
-                  }
-                  setService4(true);
-                }}
-              />
-              개인정보 수집 및 이용 동의 (필수)
-              <img
-                src="/images/detail.png"
-                style={{ marginLeft: "auto", width: "6px" }}
-                onClick={() => {
-                  navigate("/service");
-                }}
-              />
-            </List.Item>
-            <List.Item
-              style={{ display: "flex", justifyContent: "flex-start" }}
-            >
-              <CheckIcon
-                style={{ fontFamily: "PretendardRegular", fontSize: "14px" }}
-                className={iconStyle5}
-                onClick={() => {
-                  if (iconStyle5 === "enabled") {
-                    setIconStyle5("disabled");
-                  } else {
-                    setIconStyle5("enabled");
-                  }
-                  setService5(true);
-                }}
-              />
-              마케팅 수신 동의 (선택)
-              <img
-                src="/images/detail.png"
-                style={{ marginLeft: "auto", width: "6px" }}
-                onClick={() => {
-                  navigate("/service");
-                }}
-              />
-            </List.Item>
-          </List>
-        </div>
-        {nameCheck &&
-        emailCheck &&
-        equalPw == pw &&
-        pwCheck &&
-        service2 &&
-        service3 &&
-        service4 ? (
-          <>
-            <button
-              onClick={() => {
-                navigate("/signup2");
-              }}
-              className="login-button"
-            >
-              다음
-            </button>
-            <br />
-          </>
-        ) : (
-          <>
-            <button
-              disabled
-              className="login-button"
-              style={{ opacity: "0.5" }}
-            >
-              다음
-            </button>
-            <br />
-          </>
-        )}
-      </div>
-    </>
-  );
-}
-
-export default Signup1;
+        </div> */

--- a/src/components/signup/signup2.components.jsx
+++ b/src/components/signup/signup2.components.jsx
@@ -1,15 +1,12 @@
 import { useState } from "react";
 import axios from "axios";
 import "./signup2.components.css";
-import { Button } from "@nextui-org/react";
-import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
-import CheckIcon from "@mui/icons-material/Check";
-import { Input, Switch } from "antd";
-import { List, Typography, Divider } from "antd";
+import { Input } from "antd";
 import { useNavigate } from "react-router-dom";
 
-function Signup2({ email, password, realname, emailAgree, snsAgree }) {
+function Signup2({ email, password, name, emailAgree, snsAgree }) {
   const [username, setUsername] = useState("");
+  const navigate = useNavigate();
 
   function attemptSignup() {
     axios
@@ -18,7 +15,7 @@ function Signup2({ email, password, realname, emailAgree, snsAgree }) {
         {
           email: email,
           password: password,
-          realname: realname,
+          realname: name,
           username: username,
           email_agree: emailAgree,
           sns_agree: snsAgree,
@@ -28,6 +25,14 @@ function Signup2({ email, password, realname, emailAgree, snsAgree }) {
         }
       )
       .then(function (response) {
+        console.log({
+          email: email,
+          password: password,
+          realname: name,
+          username: username,
+          email_agree: emailAgree,
+          sns_agree: snsAgree,
+        })
         if (response.status === 201) {
           sessionStorage.setItem("username", username);
           navigate("/onboard1");
@@ -43,27 +48,8 @@ function Signup2({ email, password, realname, emailAgree, snsAgree }) {
       });
   }
 
-  let navigate = useNavigate();
   return (
     <>
-      <div className="header">
-        <ArrowBackIosIcon
-          className="back-arrow"
-          onClick={() => {
-            navigate("/signup1");
-          }}
-        />
-        <span
-          className="title"
-          style={{
-            fontFamily: "PretendardMedium",
-            fontSize: "18px",
-            color: "black",
-          }}
-        >
-          회원가입 (2/2)
-        </span>
-      </div>
       <p
         className="text1"
         style={{
@@ -99,17 +85,14 @@ function Signup2({ email, password, realname, emailAgree, snsAgree }) {
         </p>
         <Input
           id="inputID"
-          className="nickname-input"
+          className="nickname-input inputText"
           size="large"
           placeholder="plan-it"
           onChange={(e) => {
             setUsername(e.target.value);
           }}
           style={{
-            width: "327px",
             marginBottom: "200px",
-            borderRadius: "5px",
-            borderColor: "#EDEDED",
           }}
         />
       </div>

--- a/src/components/signup/visibility.conponents.jsx
+++ b/src/components/signup/visibility.conponents.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
+import VisibilityOffOutlinedIcon from '@mui/icons-material/VisibilityOffOutlined';
+
+function Visibility({ visible, setVisible }) {
+    const style = {
+        marginLeft: "10px",
+        color: "CECECE",
+    }
+
+    return (
+        visible ? 
+        <VisibilityOutlinedIcon onClick={() => setVisible(!visible)} style={style} /> : 
+        <VisibilityOffOutlinedIcon onClick={() => setVisible(!visible)} style={style} />
+  )
+}
+
+export default Visibility


### PR DESCRIPTION
## 1. Signup 컴포넌트 생성
기존의 app에서 모든 state를 내려주는 구조가 적합하지 않다고 생각되어서
signup 기능에 대한 state를 내려주는 컴포넌트를 새로 만들었습니다.
(이 부분은 추후 redux를 도입해서 정리해도 좋을 것 같음)
기존에 signup1, signup2, service로 나뉘었던 route를 signup으로 합쳤습니다.
state를 모두 `SignUp` 컴포넌트에서 관리하고, state에 따라 다른 페이지를 보여주
도록 만들었기 때문에, 회원가입 중 페이지를 이동하거나, 기존 /service에 해당
하는 부분으로 이동해도 작성한 email, password 등이 보존됩니다.

## 2. service 구조 변경
기존에 상세한 약관이 나오던 `Service` 컴포넌트를 `ServiceDetail` 컴포넌트로 새로
만들고, signup1의 서비스 정책부분을 `Service` 라는 컴포넌트로 빼내었습니다.
`ServiceDetail`은 `Service` 컴포넌트 안에 modal 형식으로 나타나도록 수정했습니다.

## 3. visibility 기능 추가
비밀번호의 내용을 볼 수 있게 하는 기능을 추가했습니다.

## 4. 리팩토링
중복된 부분을 제거하였습니다. 
* style이 인라인으로 중복해서 적용된 것은 특별한 이유가 아닌 이상 className을 주고 css로 빼내었습니다.
* `Service`에서 list.item을 반복문을 이용해 부분적으로 대체했습니다.

## 5. 스타일 수정
프론트 QA 보고 몇 가지 수정했습니다.
* 인풋 박스 크기 통일
* 서비스 정책 border 제거
* radius 설정
* 서비스 체크박스 크기, 색깔 수정
* 서비스 정책 marignLeft 수정