### PR TITLE
Todo 페이지 리팩토링

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ import Detail from "./components/todotest/detail.todotest.components";
 import BuyTemplate from "./components/wishtemplate/buytemplate.components";
 import UseTemplate from "./components/wishtemplate/usetemplate.components";
 import SignUp from "./components/signup/signUp.components";
+import Todo from "./components/todo/Todo.components";
 
 function App() {
   // const [email, setEmail] = useState("");
@@ -47,7 +48,7 @@ function App() {
         <Routes>
           <Route path="/" element={<Login />} />
           <Route path="/signup" element={<SignUp />} />
-
+          <Route path="/main/todo" element={<Todo />} />
           {/* <Route
             path="/signup1"
             element={

--- a/src/components/globalcomponents/BottomNavBar.components.jsx
+++ b/src/components/globalcomponents/BottomNavBar.components.jsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { BottomNavigation, BottomNavigationAction } from "@mui/material";
+import { Link } from "react-router-dom";
+import constants from "../../constants";
+
+const BottomNavBar = () => {
+  const [value, setValue] = useState(0);
+  const current = ["TODO", "PLAN"];
+  return (
+    <>
+      <BottomNavigation
+        className="BottomNavBar"
+        height="140px"
+        value={value}
+        onChange={(e, newValue) => {
+          setValue(newValue);
+        }}
+        showLabels
+      >
+        <BottomNavigationAction
+          icon={
+            <img
+              src={
+                current[value] === "TODO"
+                  ? constants.TODO_COLORED
+                  : constants.TODO_UNCOLORED
+              }
+              width={36}
+              height={36}
+            />
+          }
+          component={Link}
+          to="/main/todo"
+        />
+
+        <BottomNavigationAction
+          icon={
+            <img
+              src={
+                current[value] === "PLAN"
+                  ? constants.PLAN_COLORED
+                  : constants.PLAN_UNCOLORED
+              }
+              width={36}
+              height={36}
+            />
+          }
+          component={Link}
+          to="/main/maintemplategrowth"
+        />
+      </BottomNavigation>
+      <div
+      // 추후 삭제: <></>를 div로 바꿀 예정
+        style={{
+          height: "33px",
+          backgroundColor: "white",
+          right: 0,
+          left: 0,
+          position: "fixed",
+          bottom: 0,
+          textAlign: "center",
+        }}
+      />
+    </>
+  );
+};
+
+export default BottomNavBar;

--- a/src/components/globalcomponents/bottomnavbarplan.components.jsx
+++ b/src/components/globalcomponents/bottomnavbarplan.components.jsx
@@ -25,7 +25,7 @@ const BottomNavBarPlan = () => {
           />
         }
         component={Link}
-        to="/main/todoplan"
+        to="/main/todo"
       />
 
       <BottomNavigationAction

--- a/src/components/login/login.components.jsx
+++ b/src/components/login/login.components.jsx
@@ -31,7 +31,7 @@ function Login() {
         sessionStorage.setItem("token", response.data.token);
         sessionStorage.setItem("email", response.data.email);
         sessionStorage.setItem("password", response.data.password);
-        navigate("/main/todoplan");
+        navigate("/main/todo");
       })
       .catch((error) => {
         if (error.response.status === 400) {

--- a/src/components/signup/service.components.css
+++ b/src/components/signup/service.components.css
@@ -1,5 +1,4 @@
 .ant-card-body {
-  height: 50px;
   padding-top: 10px !important;
   padding-left: 20px !important;
 }
@@ -7,11 +6,13 @@
 .container {
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   font-family: "KoreanDefault";
   background-color: #fbfbfb;
   position:relative;
+  height: 100vh;
+  width: 327px;
 }
 
 .serviceDetail {

--- a/src/components/todo/Calendar.components.jsx
+++ b/src/components/todo/Calendar.components.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { MuiPickersUtilsProvider, DatePicker } from "@material-ui/pickers";
+import { ko } from "date-fns/locale";
+import DateFnsUtils from "@date-io/date-fns";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+
+function Calendar({selectedDate, setSelectedDate}) {
+  const dateStyle = {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    marginRight: 30,
+  };
+
+  const handleDateChange = (date) => {
+    sessionStorage.setItem("date", date);
+    setSelectedDate(new Date(sessionStorage.getItem("date")));
+  };
+
+  return (
+    <MuiPickersUtilsProvider
+      locale={ko}
+      utils={DateFnsUtils}
+      style={{ fontFamily: "Pretendard-SemiBold" }}
+    >
+      <div style={dateStyle}>
+        <DatePicker
+          style={{
+            width: "auto",
+            fontFamily: "Pretendard-SemiBold",
+          }}
+          InputProps={{
+            disableUnderline: true,
+          }}
+          disableToolbar
+          format="M월 d일 eee요일"
+          margin="normal"
+          value={selectedDate}
+          className="date"
+          onChange={handleDateChange}
+        />
+        <ExpandMoreIcon
+          color="black"
+          fontSize="large"
+          style={{
+            padding: 0,
+            marginTop: 5,
+            marginRight: 10,
+          }}
+        />
+      </div>
+    </MuiPickersUtilsProvider>
+  );
+}
+
+export default Calendar;

--- a/src/components/todo/EditFooter.components.jsx
+++ b/src/components/todo/EditFooter.components.jsx
@@ -1,0 +1,78 @@
+import axios from "axios";
+import constants from "../../constants";
+
+function EditFooter({
+  current,
+  delay,
+  accessToken,
+  update,
+  setUpdate,
+  updateMy,
+  setUpdateMy,
+}) {
+
+  const delayTodo = () => {
+    for (let i = 0; i < delay.length; i++) {
+      axios
+        .post(
+          `https://myplanit.link/todos/${current.toLowerCase()}/${
+            delay[i]
+          }/delay`,
+          { token: `Bearer ${accessToken}` },
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        )
+        .then(() => {
+          current === "PLAN" ? setUpdate(!update) : setUpdateMy(!updateMy);
+        });
+    }
+  };
+
+  const deleteTodo = () => {
+    for (let i = 0; i < delay.length; i++) {
+      axios
+        .delete(`https://myplanit.link/todos/my/${delay[i]}/delete`, {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+          },
+        })
+        .then(() => {
+          setUpdateMy(!updateMy);
+        });
+    }
+  };
+  return (
+    <div
+      style={{
+        right: 0,
+        left: 0,
+        height: "90px",
+        backgroundColor: "#7965f4",
+        position: "fixed",
+        bottom: 0,
+        display: "flex",
+        justifyContent: "space-evenly"
+      }}
+    >
+      <img
+        src={constants.DO_TOMORROW}
+        style={{ width: 35, height: 36, margin: "15px 30px" }}
+        onClick={delayTodo}
+      />
+      {current === "MY" && (
+        <img
+          src={constants.DELETE}
+          style={{ width: 35, height: 36, margin: "15px 30px" }}
+          onClick={deleteTodo}
+        />
+      )}
+    </div>
+  );
+}
+
+export default EditFooter;

--- a/src/components/todo/LinkToMyPlan.components.jsx
+++ b/src/components/todo/LinkToMyPlan.components.jsx
@@ -1,0 +1,23 @@
+import { Link } from "react-router-dom";
+import { Button } from "antd";
+
+function LinkToMyPlan() {
+  return (
+    <Link to="../main/buytemplate">
+      <Button
+        style={{
+          marginLeft: 20,
+          height: 25,
+          width: 73,
+          fontSize: 9,
+          marginTop: 10,
+          fontFamily: "SFProDisplay",
+        }}
+      >
+        MY PLAN
+      </Button>
+    </Link>
+  );
+}
+
+export default LinkToMyPlan;

--- a/src/components/todo/MyTodo.components.jsx
+++ b/src/components/todo/MyTodo.components.jsx
@@ -1,0 +1,69 @@
+import axios from "axios";
+import { Card, Checkbox } from "antd";
+
+function MyTodo({
+  todo,
+  accessToken,
+  updateMy,
+  setUpdateMy,
+  edit,
+  delay,
+  setDelay,
+}) {
+  const isChecked = todo["finish_flag"];
+  const selected = delay.includes(todo["id"]);
+  const checkMyTodo = async (todo) => {
+    try {
+      await axios
+        .post(
+          `https://myplanit.link/todos/my/${todo["id"]}/check`,
+          { token: `Bearer ${accessToken}` },
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        )
+        .then(() => {
+          setUpdateMy(!updateMy);
+        });
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  const selectTodo = (item) => {
+    if (selected) {
+      setDelay(delay.filter((i) => i !== item["id"]));
+    } else {
+      setDelay([...delay, item["id"]]);
+    }
+  };
+  return (
+    <Card
+      style={{
+        borderRadius: 5,
+        width: 327,
+        marginTop: 9,
+        height: 52,
+      }}
+    >
+      <Checkbox
+        style={{
+          marginLeft: 0,
+          marginTop: 14,
+        }}
+        disabled={isChecked && edit}
+        checked={isChecked}
+        onChange={() => (edit? selectTodo(todo): checkMyTodo(todo))}
+      >
+        <span style={{ marginLeft: 5, fontFamily: "Pretendard-Medium" }}>
+          {todo.todo_name}
+        </span>
+      </Checkbox>
+    </Card>
+  );
+}
+
+export default MyTodo;

--- a/src/components/todo/NewMyTodo.components.jsx
+++ b/src/components/todo/NewMyTodo.components.jsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import axios from "axios";
+import { Input } from "antd";
+import Sheet from "react-modal-sheet";
+import { Button } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+
+function NewMyTodo({
+  selectedDate,
+  accessToken,
+  updateMy,
+  setUpdateMy,
+}) {
+  const [isOpen, setOpen] = useState(false);
+  const [todo, setTodo] = useState([]);
+  return (
+    <>
+      <Button
+        style={{
+          backgroundColor: "#7965f4",
+          position: "absolute",
+          bottom: "110px",
+          right: "-10px",
+        }}
+        onClick={() => {
+          setOpen(true);
+        }}
+        size="large"
+        type="primary"
+        shape="circle"
+        icon={<PlusOutlined />}
+      />
+
+      <Sheet isOpen={isOpen} onClose={() => setOpen(false)} snapPoints={[250]}>
+        <Sheet.Container>
+          <Sheet.Header />
+          <Sheet.Content>
+            <Input
+              className="email-input"
+              size="large"
+              placeholder="오늘 할 일을 입력해주세요.."
+              onChange={(e) => {
+                setTodo(e.target.value);
+              }}
+              value={todo}
+              style={{
+                display: "block",
+                marginLeft: "auto",
+                marginRight: "auto",
+                width: "350px",
+                fontFamily: "PretendardRegular",
+                fontSize: "16px",
+                color: "black",
+              }}
+            />
+            <button
+              onClick={() => {
+                axios
+                  .post(
+                    `https://myplanit.link/todos/my/${selectedDate.getFullYear()}-${(
+                      "0" +
+                      (selectedDate.getMonth() + 1)
+                    ).slice(-2)}-${("0" + selectedDate.getDate()).slice(-2)}`,
+                    {
+                      todo_name: todo,
+                    },
+                    {
+                      headers: {
+                        "Content-Type": "application/json",
+                        Authorization: `Bearer ${accessToken}`,
+                      },
+                    }
+                  )
+                  .then(() => {
+                    setUpdateMy(!updateMy);
+                    setOpen(false);
+                    setTodo("");
+                  });
+              }}
+              className="todo-add-button"
+              style={{
+                display: "block",
+                marginLeft: "auto",
+                marginRight: "auto",
+              }}
+            >
+              추가하기
+            </button>
+          </Sheet.Content>
+        </Sheet.Container>
+
+        <Sheet.Backdrop />
+      </Sheet>
+    </>
+  );
+}
+
+export default NewMyTodo;

--- a/src/components/todo/Plan.components.jsx
+++ b/src/components/todo/Plan.components.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Card } from "antd";
+import PlanTodo from "./PlanTodo.components";
+
+function Plan({
+  accessToken,
+  edit,
+  update,
+  setUpdate,
+  delay,
+  setDelay,
+  i,
+  plan,
+}) {
+  const title = plan[0].length > 15 ? plan[0].slice(0, 14) + "..." : plan[0];
+  const percent = plan[1][0]["달성률"];
+  const todos = plan[1].slice(1);
+
+  const cardStyle = {
+    borderRadius: 5,
+    width: 327,
+    marginTop: 9,
+  };
+
+  const achievement = (
+    <>
+      <span style={{ color: "#8977F7" }}>{percent}%</span>
+      <span
+        style={{
+          fontFamily: "Pretendard-Medium",
+          marginLeft: 5,
+        }}
+      >
+        달성
+      </span>
+    </>
+  );
+
+  return (
+    <Card
+      key={i}
+      style={cardStyle}
+      title={title}
+      extra={achievement}
+      headStyle={{ border: "none", padding: "0 20px" }}
+      bodyStyle={{paddingBottom: "20px"}}
+    >
+      <hr style={{ opacity: 0.2, margin: 0 }} />
+      {todos.map((item, i) => {
+        return (
+          <PlanTodo
+            key={i}
+            item={item}
+            accessToken={accessToken}
+            update={update}
+            setUpdate={setUpdate}
+            edit={edit}
+            delay={delay}
+            setDelay={setDelay}
+          />
+        );
+      })}
+    </Card>
+  );
+}
+
+export default Plan;

--- a/src/components/todo/PlanTodo.components.jsx
+++ b/src/components/todo/PlanTodo.components.jsx
@@ -1,0 +1,82 @@
+import { Checkbox } from "antd";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import constants from "../../constants";
+
+function PlanTodo({
+  item,
+  accessToken,
+  update,
+  setUpdate,
+  edit,
+  delay,
+  setDelay,
+}) {
+  const navigate = useNavigate();
+  const todoName = item["plan_todo"];
+  const isChecked = item["finish_flag"];
+  const selected = delay.includes(item["id"]);
+  const checkTodo = async (item) => {
+    axios
+      .post(
+        `https://myplanit.link/todos/plan/${item["plan_id"]}/${item["id"]}/check`,
+        { token: `Bearer ${accessToken}` },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      )
+      .then(() => {
+        setUpdate(!update);
+      });
+  };
+
+  const selectTodo = (item) => {
+    if (selected) {
+      setDelay(delay.filter((i) => i !== item["id"]));
+    } else {
+      setDelay([...delay, item["id"]]);
+    }
+  };
+
+  const detailIcon = (
+    <img
+      src={constants.DETAIL_ICON}
+      style={{
+        width: 6,
+        marginLeft: "auto",
+      }}
+    />
+  );
+
+  return (
+    <Checkbox
+      disabled={isChecked && edit}
+      checked={isChecked}
+      onChange={() => (edit ? selectTodo(item) : checkTodo(item))}
+      style={{
+        marginLeft: 0,
+        marginTop: 14,
+      }}
+    >
+      <span
+        style={{
+          display: "flex",
+          width: "255px",
+        }}
+      >
+        <span style={{ fontFamily: "Pretendard-Medium" }}>{todoName}</span>
+        <span
+          onClick={() => navigate(`/todo/detail/${item["todo_id"]}`)}
+          style={{ marginLeft: "auto" }}
+        >
+          {detailIcon}
+        </span>
+      </span>
+    </Checkbox>
+  );
+}
+
+export default PlanTodo;

--- a/src/components/todo/Todo.components.jsx
+++ b/src/components/todo/Todo.components.jsx
@@ -1,0 +1,163 @@
+import { useState, useEffect } from "react";
+import BottomNavBar from "../globalcomponents/BottomNavBar.components";
+import axios from "axios";
+import { Oval } from "react-loader-spinner";
+import TodoHeader from "./TodoHeader.components";
+import TodoPlan from "./TodoPlan.components";
+import TodoMy from "./TodoMy.components";
+import EditFooter from "./EditFooter.components";
+
+function Todo() {
+  const accessToken = sessionStorage.getItem("token");
+  const [update, setUpdate] = useState(false);
+  const [updateMy, setUpdateMy] = useState(false);
+
+  const [selectedDate, setSelectedDate] = useState(
+    sessionStorage.getItem("date")
+      ? new Date(sessionStorage.getItem("date"))
+      : new Date()
+  );
+  const [current, setCurrent] = useState("PLAN");
+  const [planData, setPlanData] = useState();
+  const [myTodoData, setMyTodoData] = useState();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [edit, setEdit] = useState(false);
+  const [delay, setDelay] = useState([]);
+
+  const fetchPlan = async () => {
+    try {
+      await axios
+        .get(
+          `https://myplanit.link/todos/plan/${selectedDate.getFullYear()}-${(
+            "0" +
+            (selectedDate.getMonth() + 1)
+          ).slice(-2)}-${("0" + selectedDate.getDate()).slice(-2)}`,
+          {
+            Authorization: `Bearer ${accessToken}`,
+            withCredentials: true,
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        )
+        .then((response) => {
+          setPlanData(Object.entries(response.data));
+        });
+    } catch (err) {
+      setError(err);
+      console.log(err);
+    }
+  };
+
+  const fetchMyTodo = async () => {
+    try {
+      await axios
+        .get(
+          `https://myplanit.link/todos/my/${selectedDate.getFullYear()}-${(
+            "0" +
+            (selectedDate.getMonth() + 1)
+          ).slice(-2)}-${("0" + selectedDate.getDate()).slice(-2)}`,
+          {
+            Authorization: `Bearer ${accessToken}`,
+            withCredentials: true,
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        )
+        .then((response) => {
+          setMyTodoData(response.data.personal_todos);
+        });
+    } catch (err) {
+      setError(err);
+      console.log(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchPlan();
+    setEdit(false);
+    setDelay([]);
+  }, [selectedDate, update]);
+
+  useEffect(() => {
+    fetchMyTodo();
+    setEdit(false);
+    setDelay([]);
+  }, [selectedDate, updateMy]);
+
+  if (loading)
+    return (
+      <div
+        style={{
+          width: "100vw",
+          height: "100vh",
+          backgroundColor: "gray",
+          zIndex: 100000,
+        }}
+      >
+        <Oval color="#7965f4" height="40px" width="40px" />
+        <BottomNavBar />
+      </div>
+    );
+  if (error) return <div>에러가 발생했습니다</div>;
+
+  return (
+    <div className="container">
+      <TodoHeader
+        selectedDate={selectedDate}
+        setSelectedDate={setSelectedDate}
+        edit={edit}
+        setEdit={setEdit}
+        current={current}
+        setCurrent={setCurrent}
+      />
+
+      {current === "PLAN" && (
+        <TodoPlan
+          planData={planData}
+          myTodoData={myTodoData}
+          accessToken={accessToken}
+          edit={edit}
+          update={update}
+          setUpdate={setUpdate}
+          delay={delay}
+          setDelay={setDelay}
+          current={current}
+        />
+      )}
+
+      {current === "MY" && (
+        <TodoMy
+          myTodoData={myTodoData}
+          accessToken={accessToken}
+          updateMy={updateMy}
+          setUpdateMy={setUpdateMy}
+          selectedDate={selectedDate}
+          edit={edit}
+          delay={delay}
+          setDelay={setDelay}
+        />
+      )}
+
+      {!edit ? (
+        <BottomNavBar />
+      ) : (
+        <EditFooter
+          current={current}
+          delay={delay}
+          accessToken={accessToken}
+          update={update}
+          setUpdate={setUpdate}
+          updateMy={updateMy}
+          setUpdateMy={setUpdateMy}
+        />
+      )}
+    </div>
+  );
+}
+
+export default Todo;

--- a/src/components/todo/TodoHeader.components.jsx
+++ b/src/components/todo/TodoHeader.components.jsx
@@ -1,0 +1,101 @@
+import Calendar from "./Calendar.components";
+import LinkToMyPlan from "./LinkToMyPlan.components";
+
+function TodoHeader({
+  selectedDate,
+  setSelectedDate,
+  edit,
+  setEdit,
+  current,
+  setCurrent,
+}) {
+  const headerContainer = {
+    position: "fixed",
+    top: 0,
+    zIndex: 999,
+    backgroundColor: "#fbfbfb",
+    height: "110px",
+  };
+
+  const upperHeader = {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+  };
+
+  const linkStyle = (text) => ({
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    height: "20px",
+    marginTop: "0px",
+    background: "#fbfbfb",
+    borderRadius: "0",
+    borderWidth: "0px 0px 0px",
+    fontFamily: "SFProDisplay",
+    fontSize: "16px",
+    marginRight: 15,
+    padding: "0 0 1px",
+    boxSizing: "border-box",
+
+    color: current===text? "black": "gray",
+    borderBottom: current===text ? " 2px solid #8977F4": "none",
+    paddingBottom: current===text ? "4px": "6px",
+  });
+
+  const lowerHeader = {
+    display: "flex",
+    fontSize: "16px",
+    fontWeight: "bold",
+    position: "relative"
+  };
+
+  const linkText = ["PLAN", "MY"];
+
+  return (
+    <div style={headerContainer}>
+      <div style={upperHeader}>
+        <Calendar
+          selectedDate={selectedDate}
+          setSelectedDate={setSelectedDate}
+        />
+        <LinkToMyPlan />
+      </div>
+
+      <div style={lowerHeader}>
+        {linkText.map((item, i) =>
+          <button
+            key={i}
+            style={linkStyle(item)}
+            onClick={() => setCurrent(item)}
+          >
+            {item}
+          </button>
+        )}
+          <p
+            style={{
+              marginTop: 0,
+              position: "absolute",
+              right: 0,
+              fontSize: "12px",
+              color: edit ? "#8977F7" : "#929292",
+              fontFamily: "Pretendard-Medium",
+            }}
+            onClick={() => {
+              setEdit(!edit);
+            }}
+          >
+            {edit && (
+              <img
+                src="/images/purpletick.png"
+                style={{ width: "12px", marginRight: 4 }}
+              />
+            )}
+            {edit ? "편집완료" : "편집하기"}
+          </p>
+        </div>
+    </div>
+  );
+}
+
+export default TodoHeader;

--- a/src/components/todo/TodoMy.components.jsx
+++ b/src/components/todo/TodoMy.components.jsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import MyTodo from "./MyTodo.components";
+import constants from "../../constants";
+import NewMyTodo from "./NewMyTodo.components";
+
+function TodoMy({
+  myTodoData,
+  accessToken,
+  updateMy,
+  setUpdateMy,
+  selectedDate,
+  edit,
+  delay,
+  setDelay
+}) {
+  const contentsStyle = {
+    display:"flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+    marginTop: "100px",
+    bottom: "50px",
+    fontFamily: "Pretendard-SemiBold",
+  };
+  const todoExist = myTodoData?.length;
+  const noTodoImg = (
+    <img
+      src={constants.NO_TODO_IMG}
+      style={{ width: "80%", marginTop: "140px" }}
+    />
+  );
+
+  return (
+    <div style={contentsStyle}>
+      {todoExist
+        ? myTodoData.map((todo, i) => (
+            <MyTodo
+              accessToken={accessToken}
+              updateMy={updateMy}
+              setUpdateMy={setUpdateMy}
+              key={i}
+              todo={todo}
+              edit={edit}
+              delay={delay}
+              setDelay={setDelay}
+            />
+          ))
+        : noTodoImg}
+
+      <NewMyTodo
+        selectedDate={selectedDate}
+        accessToken={accessToken}
+        updateMy={updateMy}
+        setUpdateMy={setUpdateMy}
+      />
+    </div>
+  );
+}
+
+export default TodoMy;

--- a/src/components/todo/TodoPlan.components.jsx
+++ b/src/components/todo/TodoPlan.components.jsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import constants from "../../constants";
+import Plan from "./Plan.components";
+
+function TodoPlan({
+  planData,
+  accessToken,
+  edit,
+  update,
+  setUpdate,
+  delay,
+  setDelay,
+}) {
+  const navigate = useNavigate();
+  const contentsStyle = {
+    display:"flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+    marginTop: "100px",
+    bottom: "50px",
+    fontFamily: "Pretendard-SemiBold",
+  };
+  const planExist = planData?.length;
+  const noPlanImg = (
+    <img
+      style={{ width: "80%", marginTop: "50px" }}
+      src={constants.NO_PLAN_IMG}
+      onClick={() => {
+        navigate("/main/maintemplategrowth");
+      }}
+    />
+  );
+
+  return (
+    <div style={contentsStyle}>
+      {planExist
+        ? planData.map((plan, i) => (
+            <Plan
+              accessToken={accessToken}
+              edit={edit}
+              update={update}
+              setUpdate={setUpdate}
+              delay={delay}
+              setDelay={setDelay}
+              i={i}
+              key={i}
+              plan={plan}
+            />
+          ))
+        : noPlanImg}
+    </div>
+  );
+}
+
+export default TodoPlan;

--- a/src/components/todotest/detail.todotest.components.jsx
+++ b/src/components/todotest/detail.todotest.components.jsx
@@ -57,7 +57,7 @@ function Detail() {
           zIndex: "20",
         }}
       >
-        <Link to="../main/todoplan">
+        <Link to="../main/todo">
           <ArrowBackIosIcon style={{ color: "#7965f4" }} />
         </Link>
       </div>

--- a/src/components/wishtemplate/buytemplate.components.jsx
+++ b/src/components/wishtemplate/buytemplate.components.jsx
@@ -53,7 +53,7 @@ function BuyTemplate() {
           style={{ background: "white", width: "100vw" }}
         >
           <Toolbar style={{ justifyContent: "space-between" }}>
-            <Link to="../main/todoplan">
+            <Link to="../main/todo">
               <ArrowBackIosIcon style={{ color: "black" }} />
             </Link>
             <Typography
@@ -100,7 +100,7 @@ function BuyTemplate() {
         style={{ background: "white", width: "100vw" }}
       >
         <Toolbar style={{ justifyContent: "space-between" }}>
-          <Link to="../main/todoplan">
+          <Link to="../main/todo">
             <ArrowBackIosIcon style={{ color: "black" }} />
           </Link>
           <Typography

--- a/src/components/wishtemplate/usetemplate.components.jsx
+++ b/src/components/wishtemplate/usetemplate.components.jsx
@@ -68,7 +68,7 @@ function UseTemplate() {
           style={{ background: "white", width: "100vw" }}
         >
           <Toolbar style={{ justifyContent: "space-between" }}>
-            <Link to="../main/todoplan">
+            <Link to="../main/todo">
               <ArrowBackIosIcon style={{ color: "black" }} />
             </Link>
             <Typography
@@ -115,7 +115,7 @@ function UseTemplate() {
         style={{ background: "white", width: "100vw" }}
       >
         <Toolbar style={{ justifyContent: "space-between" }}>
-          <Link to="../main/todoplan">
+          <Link to="../main/todo">
             <ArrowBackIosIcon style={{ color: "black" }} />
           </Link>
           <Typography

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,17 @@
+const constants = {
+  TODO_COLORED:
+    "https://firebasestorage.googleapis.com/v0/b/single-life-manager.appspot.com/o/ceos%20test%2Ftodo3.png?alt=media&token=31e75be2-ab09-424c-9a43-745d4316beff",
+  TODO_UNCOLORED:
+    "https://firebasestorage.googleapis.com/v0/b/single-life-manager.appspot.com/o/ceos%20test%2Ftodoc.png?alt=media&token=3f20e0e8-1b61-4c72-a99b-a2d3fe24949e",
+  PLAN_COLORED:
+    "https://firebasestorage.googleapis.com/v0/b/single-life-manager.appspot.com/o/ceos%20test%2Ftodod.png?alt=media&token=55c5a1c6-a771-4619-ae0e-fa6a674683e3",
+  PLAN_UNCOLORED:
+    "https://firebasestorage.googleapis.com/v0/b/single-life-manager.appspot.com/o/ceos%20test%2Ftodof.png?alt=media&token=52344e83-350a-490d-83dc-144dd547bb52",
+  NO_PLAN_IMG: "/images/plan.png",
+  NO_TODO_IMG: "/images/my.png",
+  DO_TOMORROW: "/images/next.png",
+  DELETE: "/images/delete.png",
+  DETAIL_ICON: "/images/detail.png"
+};
+
+export default constants;


### PR DESCRIPTION
## 1. Todo 페이지 리팩토링
일단 state나 함수 등은 거의 수정한 부분이 없고, render 부분에 중복된 부분 제거하고 컴포넌트로 빼내는 작업만 했습니다.
**readability 높이는 작업만 했다고 보면 됩니다**. 리덕스 도입하면서, 구조나 로직을 다시 개선할 계획입니다.
컴포넌트가 되게 많아졌는데, 코드 읽어보면 알겠지만 구조는 대충 다음과 같습니다.
```
**Todo**
├TodoHeader
├TodoPlan / TodoMy
└BottomNavBar / EditFooter

TodoHeader
└Calender, LinkToMyPlan

TodoPlan
└ Plan-PlanTodo

TodoMy
├MyTodo
└NewTodo
```
컴포넌트 이름이 되게 헷갈리게 지어져서 같이 의논해서 다시 정하면 좋을 것 같습니다.
코드들 보면 인라인 style을 const 변수로 빼놓은 것들이 있는데, 이거는 render 부분 더 읽기 좋게 하려고 한 것도 있고, 추후 styled component 도입했을 때 사용하려고 빼놨습니다.
수정하면서 route도 일단 /todo 하나로 합쳐졌습니다. 

## 2. constants 파일 생성
이미지 src 같은 거는 하드코딩하는 대신 constants에 저장해놓고 사용하는게 좋을 것 같습니당. 일단 지금까지는 이미지들이 거의 한번씩 쓰이고 있어서 상관이 없긴하지만, 여러 군데에 쓰일 경우 수정할 때 찾아서 하나하나 다 수정하는거 보다는 constants 파일 하나만 수정하는게 편하니까여

## 3. route 수정
기존 todomy, todoplan을 남겨놓긴 했지만, app.js 및 다른 컴포넌트들에서 todo로 가는 link를 다 수정해놓은 상태입니다.
모두 <Todo/> 컴포넌트가 랜더링 되도록 수정했습니다.