### PR TITLE
#10번, #13번 이슈 수정

### DIFF
--- a/public/images/proposal.svg
+++ b/public/images/proposal.svg
@@ -1,0 +1,7 @@
+<svg width="21" height="18" viewBox="0 0 21 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 7L9 12L17 7L9 2L1 7Z" stroke="black" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17 7V15.3333C17 15.7754 16.8127 16.1993 16.4793 16.5118C16.1459 16.8244 15.6937 17 15.2222 17H2.77778C2.30628 17 1.8541 16.8244 1.5207 16.5118C1.1873 16.1993 1 15.7754 1 15.3333V7" stroke="black" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1 15.3333L6.33333 10.3333" stroke="black" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.6667 10.3333L17 15.3333" stroke="black" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="19" cy="2" r="2" fill="#7965F4"/>
+</svg>

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import MyPlan from "./components/myplan/MyPlan.components";
 import TodoDetail from "./components/todo/TodoDetail.components";
 import PlanDetail from "./components/todo/PlanDetail.components";
 import PlanMarket from "./components/planmarket/PlanMarket.components";
+import Proposal from "./components/proposal/Proposal.components";
 import KakaoSocial from "./components/social/KakaoSocial.components";
 import GoogleSocial from "./components/social/GoogleSocial.components";
 import Admin from "./components/admin/admin.components";
@@ -36,6 +37,7 @@ function App() {
         <Route path="/myplan" element={<MyPlan />} />
 
         <Route path="/planmarket" element={<PlanMarket />} />
+        <Route path="/proposal" element={<Proposal />} />
 
         <Route path="/main/viewtemplate/:id" element={<ViewTemplate />} />
         <Route path="/main/searchtemplate" element={<SearchTemplate />} />

--- a/src/components/planmarket/PlanMarket.components.jsx
+++ b/src/components/planmarket/PlanMarket.components.jsx
@@ -1,29 +1,23 @@
 import { useState, useEffect } from "react";
-import { NavLink } from "react-router-dom";
 import axios from "axios";
-import { v4 as uuidv4 } from "uuid";
 import BottomNavBar from "../globalcomponents/BottomNavBar.components";
-import { Oval } from "react-loader-spinner";
 import styled from "styled-components";
 import PlanMarketHeader from "./PlanMarketHeader.components";
 import PlanMarketContent from "./PlanMarketContent.components";
-import PlanMarketProposal from "./PlanMarketProposal.components";
 import LoadingScreen from "../globalcomponents/Loading.components";
 
 function PlanMarket() {
-  const [users, setUsers] = useState(null);
+  const [plans, setPlans] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [current, setCurrent] = useState("ROUTINE");
 
   useEffect(() => {
     const fetchUsers = async () => {
       try {
-        setError(null);
-        setUsers(null);
         setLoading(true);
         const response = await axios.get("https://myplanit.link/plans");
-        setUsers(response.data);
+        const data = response.data;
+        setPlans([...data.Routine, ...data.Growth]);
       } catch (e) {
         setError(e);
       }
@@ -41,16 +35,13 @@ function PlanMarket() {
       </div>
     );
   if (error) return <div>에러가 발생했습니다</div>;
-  if (!users) return null;
+  if (!plans) return null;
+  
   return (
     <Container>
-      <PlanMarketHeader current={current} setCurrent={setCurrent} />
+      <PlanMarketHeader/>
 
-      {current === "ROUTINE" && <PlanMarketContent plans={users.Routine} />}
-
-      {current === "GROWTH" && <PlanMarketContent plans={users.Growth} />}
-
-      {current === "PROPOSAL" && <PlanMarketProposal />}
+      <PlanMarketContent plans={plans} />
 
       <BottomNavBar current="PLAN" />
     </Container>

--- a/src/components/planmarket/PlanMarketHeader.components.jsx
+++ b/src/components/planmarket/PlanMarketHeader.components.jsx
@@ -1,79 +1,40 @@
-import React from "react";
+import {useNavigate} from "react-router-dom"
 import styled from "styled-components";
+import constants from "../../constants";
 
-function PlanMarketHeader({ current, setCurrent }) {
+function PlanMarketHeader() {
+  const navigate = useNavigate();
+
   return (
-    <>
-      <UpperHeader>
-        <Title>플랜</Title>
-      </UpperHeader>
-      <LowerHeader>
-        <LinkButton
-          selected={current === "ROUTINE"}
-          onClick={() => setCurrent("ROUTINE")}
-        >
-          Routine
-        </LinkButton>
-        <LinkButton
-          selected={current === "GROWTH"}
-          onClick={() => setCurrent("GROWTH")}
-        >
-          Growth
-        </LinkButton>
-        <LinkButton
-          selected={current === "PROPOSAL"}
-          onClick={() => setCurrent("PROPOSAL")}
-        >
-          Proposal
-        </LinkButton>
-      </LowerHeader>
-    </>
+    <Header>
+      <Title>플랜</Title>
+      <ProposalButton
+        src={constants.PROPOSAL}
+        onClick={() => navigate("../proposal")}
+      />
+    </Header>
   );
 }
 
 export default PlanMarketHeader;
 
-const UpperHeader = styled.div`
+const Header = styled.div`
   background: #fbfbfb;
   width: 327px;
   display: flex;
+  align-items: center;
   position: relative;
-  justify-content: center;
-  height: 56px;
+  margin: 10px;
 `;
 
-const LowerHeader = styled.div`
-  display: flex;
-  width: 327px;
-  margin: 8px;
-  font-size: 16px;
-  font-weight: bold;
-  margin-left: 10;
+const ProposalButton = styled.img`
+  position: absolute;
+  right: 10px;
 `;
 
 const Title = styled.div`
-  font-family: "Pretendard";
-  font-weight: 510;
-  font-size: 18px;
-  height: 56px;
-  line-height: 56px;
-`;
-
-const LinkButton = styled.button`
-  box-sizing: border-box;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: 0px;
-  background-color: #fbfbfb;
-  border-radius: 0;
-  border-width: 0px 0px 0px;
   font-family: "PretendardMedium";
-  font-size: 15px;
-  margin-right: 15px;
-  padding: 0 0 1px;
-
-  color: ${(props) => (props.selected ? "black" : "#C4C4C4")};
-  border-bottom: ${(props) => (props.selected ? "2px solid #8977f7" : "none")};
-  padding-bottom: ${(props) => (props.selected ? "2px" : "4px")};
+  font-size: 18px;
+  height: 30px;
+  line-height: 30px;
 `;

--- a/src/components/proposal/Proposal.components.jsx
+++ b/src/components/proposal/Proposal.components.jsx
@@ -1,0 +1,122 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import BottomNavBar from "../globalcomponents/BottomNavBar.components";
+import * as Styled from "./Proposal.style";
+import LoadingScreen from "../globalcomponents/Loading.components";
+import ProposalCard from "./ProposalCard.components";
+import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
+
+function Proposal() {
+  const accessToken = sessionStorage.getItem("access");
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [plans, setPlans] = useState([]);
+  const [inputText, setInputText] = useState("");
+  const [warning, setWarning] = useState(false);
+  const [update, setUpdate] = useState(false);
+  const placeholder = "필요한 플랜을 알려주시면, 다음 플랜으로 준비할게요!";
+  const warningText = "필요한 플랜을 입력해주세요!";
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setError(null);
+        setPlans(null);
+        setLoading(true);
+        const response = await axios.get("https://myplanit.link/proposal", {
+          withCredentials: true,
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+        setPlans(response.data);
+      } catch (e) {
+        setError(e);
+      }
+      setLoading(false);
+    };
+
+    fetchData();
+  }, [update]);
+
+  function SendPlan() {
+    axios
+      .post(
+        "https://myplanit.link/proposal",
+        {
+          proposal: inputText,
+        },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      )
+      .then(() => {
+        setInputText("");
+        setUpdate(!update);
+      });
+  }
+
+  const onClickHandler = (e) => {
+    if (inputText !== "") {
+      SendPlan();
+    } else {
+      setWarning(true);
+      setTimeout(() => {
+        setWarning(false);
+      }, 2000);
+    }
+  };
+
+  if (loading)
+    return (
+      <div>
+        <LoadingScreen />
+        <BottomNavBar current="PLAN" />
+      </div>
+    );
+  if (error) return <div>에러가 발생했습니다</div>;
+  if (!plans) return null;
+
+  return (
+    <>
+      <Styled.Header>
+        <Styled.Title>건의함</Styled.Title>
+        <ArrowBackIosIcon
+          style={{ color: "black", position: "absolute", left: 0 }}
+          onClick={() => navigate(-1)}
+        />
+      </Styled.Header>
+      <Styled.InputArea>
+        <Styled.InputField
+          placeholder={warning? warningText: placeholder}
+          onChange={(e) => {
+            setInputText(e.target.value);
+          }}
+          warning={warning}
+          value={inputText}
+        />
+        <Styled.Button onClick={onClickHandler}>요청하기</Styled.Button>
+      </Styled.InputArea>
+
+      <Styled.Hr />
+
+      <Styled.Content>
+        <Styled.ContentTitle>이런 플랜이 있으면 좋겠어요!</Styled.ContentTitle>
+        <Styled.CardContainer>
+          {plans.map((plan, i) => (
+            <ProposalCard proposal={plan.proposal} num={plan.id} key={i} />
+          ))}
+        </Styled.CardContainer>
+      </Styled.Content>
+      <BottomNavBar current="PLAN" />
+    </>
+  );
+}
+
+export default Proposal;

--- a/src/components/proposal/Proposal.style.js
+++ b/src/components/proposal/Proposal.style.js
@@ -1,0 +1,90 @@
+import styled from "styled-components";
+
+export const Header = styled.div`
+  background: #fbfbfb;
+  width: 327px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  margin: 10px;
+`;
+
+export const Title = styled.div`
+  font-family: "PretendardMedium";
+  font-size: 18px;
+  height: 30px;
+  line-height: 30px;
+`;
+
+export const InputArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 10px 0 28px;
+`;
+
+export const InputField = styled.textarea`
+  ::placeholder,
+  ::-webkit-input-placeholder {
+    color: ${props => props.warning? "#F87676": "#CECECE"};
+    font-family: "PretendardRegular";
+    font-size: 13px;
+  }
+  width: 330px;
+  height: 136px;
+  border: 1px ${props => props.warning? "#F87676": "#EDEDED"} solid;
+  border-radius: 6px;
+  vertical-align: top;
+  resize: none;
+  outline: none;
+  padding: 14px;
+  font-family: "PretendardRegular";
+  font-size: 12px;
+`;
+
+export const Button = styled.button`
+  width: 327px;
+  height: 48px;
+  background-color: #7965f4;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  margin-top: 12px;
+  font-family: "PretendardMedium";
+`;
+
+export const Hr = styled.div`
+  display: flex;
+  width: 100%;
+  background-color: #f1f3f5;
+  padding: 5px 0;
+`;
+
+export const Content = styled.div`
+  margin-top: 36px;
+  display: flex;
+  flex-direction: column;
+  overflow-y: hidden;
+`;
+
+export const CardContainer = styled.div`
+  overflow-y: scroll;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 90px;
+
+`;
+
+export const ContentTitle = styled.p`
+  margin-bottom: 16px;
+  font-family: "PretendardMedium";
+  font-style: normal;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 16px;
+  letter-spacing: -0.3px;
+  width: 100%;
+`;

--- a/src/components/proposal/ProposalCard.components.jsx
+++ b/src/components/proposal/ProposalCard.components.jsx
@@ -1,0 +1,37 @@
+import styled from "styled-components";
+
+function ProposalCard({ proposal, num }) {
+  return (
+    <Card>
+      <Title>
+        🚀 {num}번째 플랜
+      </Title>
+      <Detail>{proposal}</Detail>
+    </Card>
+  );
+}
+
+const Card = styled.div`
+  width: 327px;
+  background-color: #FFFFFF;
+  border-radius: 5px;
+  border: 0.1px solid #ededed;
+  margin-bottom: 10px;
+`;
+
+const Title = styled.p`
+  font-size: 13px;
+  color: #929292;
+  margin: 12px;
+  font-family: "Pretendard";
+`;
+
+const Detail = styled.p`
+  font-size: 13px;
+  color: #000000;
+  opacity: 0.8;
+  margin: 0 12px 18px;
+  font-family: "PretendardRegular";
+`;
+
+export default ProposalCard;

--- a/src/components/todo/EditFooter.components.jsx
+++ b/src/components/todo/EditFooter.components.jsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 import constants from "../../constants";
-import styled from "styled-components";
+import * as Styled from "./EditFooter.style";
 
 function EditFooter({
   current,
@@ -47,7 +47,7 @@ function EditFooter({
           setUpdateMy(!updateMy);
         });
     }
-  }
+  };
 
   const advanceTodo = () => {
     for (let i = 0; i < delay.length; i++) {
@@ -82,56 +82,27 @@ function EditFooter({
         });
     }
   };
+  
   return (
-    <Footer>
-      {current == "PLANDETAIL" && (
-        <Button onClick={advanceTodo}>
+    <Styled.Footer>
+      {current != "MY" && (
+        <Styled.Button onClick={advanceTodo}>
           <img src={constants.DO_TOMORROW} height="19" />
-          <NavText>하루 앞당기기</NavText>
-        </Button>
+          <Styled.NavText>하루 앞당기기</Styled.NavText>
+        </Styled.Button>
       )}
-      <Button onClick={current == "MY"? delayMyTodo: delayTodo}>
+      <Styled.Button onClick={current == "MY" ? delayMyTodo : delayTodo}>
         <img src={constants.DO_TOMORROW} height="19" />
-        <NavText>
-          {current == "PLANDETAIL" ? "하루 미루기" : "내일하기"}
-        </NavText>
-      </Button>
+        <Styled.NavText>하루 미루기</Styled.NavText>
+      </Styled.Button>
       {current === "MY" && (
-        <Button onClick={deleteTodo}>
+        <Styled.Button onClick={deleteTodo}>
           <img src={constants.DELETE} height="19" />
-          <NavText>삭제하기</NavText>
-        </Button>
+          <Styled.NavText>삭제하기</Styled.NavText>
+        </Styled.Button>
       )}
-    </Footer>
+    </Styled.Footer>
   );
 }
 
 export default EditFooter;
-
-const Footer = styled.div`
-  right: 0;
-  left: 0;
-  height: 90px;
-  background-color: #8977f7;
-  position: fixed;
-  bottom: 0;
-  display: flex;
-  justify-content: space-evenly;
-  padding: 0 20px;
-`;
-
-const Button = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin: 15px 30px 30px;
-  flex: 1;
-`;
-
-const NavText = styled.span`
-  font-family: "PretendardMedium";
-  font-size: 10px;
-  font-style: normal;
-  color: #ffffff;
-  margin-top: 8px;
-`;

--- a/src/components/todo/EditFooter.style.js
+++ b/src/components/todo/EditFooter.style.js
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+
+export const Footer = styled.div`
+  right: 0;
+  left: 0;
+  height: 90px;
+  background-color: #8977f7;
+  position: fixed;
+  bottom: 0;
+  display: flex;
+  justify-content: space-evenly;
+  padding: 0 20px;
+`;
+
+export const Button = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 15px 30px 30px;
+  flex: 1;
+`;
+
+export const NavText = styled.span`
+  font-family: "PretendardMedium";
+  font-size: 10px;
+  font-style: normal;
+  color: #ffffff;
+  margin-top: 8px;
+`;

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,7 @@ const constants = {
   DO_TOMORROW: "/images/do_tomorrow.svg",
   DELETE: "/images/delete.svg",
   DETAIL_ICON: "/images/detail.png",
+  PROPOSAL: "/images/proposal.svg"
 };
 
 export default constants;


### PR DESCRIPTION
## 10번 이슈
EditFooter에 내일하기만 나오던 것을 하루 미루기, 하루 앞당기기가 나오도록 수정했슴다.

## 13번 이슈
플랜 마켓 페이지의 전반적인 UI를 수정했습니다.
### 1. 플랜 마켓 헤더 수정
Routine, Growth, Proposal로 구분되던 것을 삭제하고, Proposal을 아이콘을 클릭해서 접근하도록 했습니다.
따라서 이제 current가 필요없다고 판단되어서 proposal은 따로 페이지로 떼어냈습니다. `/proposal`로 접근할 수 있습니다.
기존에 Routine과 Growth로 나누어진 것을 fetch 과정에서 합쳐서 state로 저장하도록 수정했습니다.
### 2. 건의함 페이지 수정
디자인 수정사항에 따라서 페이지 디자인을 수정했습니다.
Card 디자인을 주로 수정했슴다.