### PR TITLE
스크롤 영역 수정, weekCalendar 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,8 +11,8 @@ import SearchTemplate from "./components/searchtemplate/searchtemplate.component
 import Todo from "./components/todo/Todo.components";
 
 import MyPlan from "./components/myplan/MyPlan.components";
-import TodoDetail from "./components/todo/TodoDetail.components";
-import PlanDetail from "./components/todo/PlanDetail.components";
+import TodoDetail from "./components/todo/detail/TodoDetail.components";
+import PlanDetail from "./components/todo/plan/PlanDetail.components";
 import PlanMarket from "./components/planmarket/PlanMarket.components";
 import Proposal from "./components/proposal/Proposal.components";
 import KakaoSocial from "./components/social/KakaoSocial.components";

--- a/src/components/myplan/MyPlan.components.jsx
+++ b/src/components/myplan/MyPlan.components.jsx
@@ -4,7 +4,6 @@ import { Loading } from "@nextui-org/react";
 import BottomNavBar from "../globalcomponents/BottomNavBar.components";
 import MyPlanHeader from "./MyPlanHeader.components";
 import MyPlanContent from "./MyPlanContent.components";
-import styled from "styled-components";
 import LoadingScreen from "../globalcomponents/Loading.components";
 
 function MyPlan() {
@@ -79,7 +78,7 @@ function MyPlan() {
     );
 
   return (
-    <Container>
+    <>
       <MyPlanHeader
         current={current}
         setCurrent={setCurrent}
@@ -93,18 +92,8 @@ function MyPlan() {
       )}
 
       <BottomNavBar current="TODO" />
-    </Container>
+    </>
   );
 }
 
 export default MyPlan;
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  background-color: #fbfbfb;
-  position: relative;
-  height: 100%;
-`;

--- a/src/components/myplan/MyPlanContent.components.jsx
+++ b/src/components/myplan/MyPlanContent.components.jsx
@@ -43,8 +43,10 @@ export default MyPlanContent;
 const Container = styled.div`
   overflow-y: scroll;
   position: relative;
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-top: 100px;
   margin-bottom: 90px;
 `;

--- a/src/components/myplan/MyPlanHeader.components.jsx
+++ b/src/components/myplan/MyPlanHeader.components.jsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 function MyPlanHeader({ current, setCurrent, buyLength, registerLength }) {
   const navigate = useNavigate();
   return (
-    <>
+    <Header>
       <UpperHeader>
         <ArrowBackIosIcon
           style={{ height: 56, color: "black", position: "absolute", left: 0 }}
@@ -28,11 +28,21 @@ function MyPlanHeader({ current, setCurrent, buyLength, registerLength }) {
           {"이용 중(" + registerLength + ")"}
         </LinkButton>
       </LowerHeader>
-    </>
+    </Header>
   );
 }
 
 export default MyPlanHeader;
+
+const Header = styled.div`
+  position: fixed;
+  z-index: 10;
+  width: 100%;
+  background: #fbfbfb;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
 
 const UpperHeader = styled.div`
   background: #fbfbfb;

--- a/src/components/planmarket/PlanMarket.components.jsx
+++ b/src/components/planmarket/PlanMarket.components.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import axios from "axios";
 import BottomNavBar from "../globalcomponents/BottomNavBar.components";
-import styled from "styled-components";
 import PlanMarketHeader from "./PlanMarketHeader.components";
 import PlanMarketContent from "./PlanMarketContent.components";
 import LoadingScreen from "../globalcomponents/Loading.components";
@@ -38,24 +37,14 @@ function PlanMarket() {
   if (!plans) return null;
   
   return (
-    <Container>
+    <>
       <PlanMarketHeader/>
 
       <PlanMarketContent plans={plans} />
 
       <BottomNavBar current="PLAN" />
-    </Container>
+    </>
   );
 }
 
 export default PlanMarket;
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  background-color: #fbfbfb;
-  position: relative;
-  height: 100%;
-`;

--- a/src/components/planmarket/PlanMarketContent.components.jsx
+++ b/src/components/planmarket/PlanMarketContent.components.jsx
@@ -28,8 +28,10 @@ export default PlanMarketContent;
 const Container = styled.div`
   overflow-y: scroll;
   position: relative;
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-top: 50px;
   margin-bottom: 90px;
 `;

--- a/src/components/planmarket/PlanMarketHeader.components.jsx
+++ b/src/components/planmarket/PlanMarketHeader.components.jsx
@@ -23,7 +23,8 @@ const Header = styled.div`
   width: 327px;
   display: flex;
   align-items: center;
-  position: relative;
+  position: fixed;
+  z-index: 10;
   margin: 10px;
 `;
 

--- a/src/components/todo/Calendar.components.jsx
+++ b/src/components/todo/Calendar.components.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { MuiPickersUtilsProvider, DatePicker } from "@material-ui/pickers";
-import { InputAdornment } from "@material-ui/core";
 import { ko } from "date-fns/locale";
 import DateFnsUtils from "@date-io/date-fns";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";

--- a/src/components/todo/NewMyTodo.components.jsx
+++ b/src/components/todo/NewMyTodo.components.jsx
@@ -77,11 +77,12 @@ export default NewMyTodo;
 
 const OpenAddModal = styled(Button)`
   background-color: #8977f7;
-  position: absolute;
+  position: fixed;
   bottom: 110px;
-  right: -10px;
+  transform: translate(150px);
   border-color: #7965f4 !important;
   box-shadow: none !important;
+  z-index: 10;
 
   &: hover {
     background-color: #8977f7;

--- a/src/components/todo/Todo.components.jsx
+++ b/src/components/todo/Todo.components.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import BottomNavBar from "../globalcomponents/BottomNavBar.components";
 import axios from "axios";
+import { format } from "date-fns";
 import TodoHeader from "./TodoHeader.components";
 import TodoPlan from "./TodoPlan.components";
 import TodoMy from "./TodoMy.components";
@@ -17,6 +18,7 @@ function Todo() {
       ? new Date(sessionStorage.getItem("date"))
       : new Date()
   );
+  
   const [current, setCurrent] = useState("PLAN");
   const [planData, setPlanData] = useState();
   const [myTodoData, setMyTodoData] = useState();
@@ -25,16 +27,11 @@ function Todo() {
   const [edit, setEdit] = useState(false);
   const [delay, setDelay] = useState([]);
 
-  const formatDate = () => {
-    const timeOffset = selectedDate.getTimezoneOffset() * 60000;
-    return new Date(selectedDate.getTime() - timeOffset).toISOString().slice(0, 10);
-  };
-
   const fetchPlan = async () => {
     try {
       await axios
         .get(
-          `https://myplanit.link/todos/plan/${formatDate()}`,
+          `https://myplanit.link/todos/plan/${format(selectedDate, "yyyy-MM-dd")}`,
           {
             Authorization: `Bearer ${accessToken}`,
             withCredentials: true,
@@ -57,7 +54,7 @@ function Todo() {
     try {
       await axios
         .get(
-          `https://myplanit.link/todos/my/${formatDate()}`,
+          `https://myplanit.link/todos/my/${format(selectedDate, "yyyy-MM-dd")}`,
           {
             Authorization: `Bearer ${accessToken}`,
             withCredentials: true,

--- a/src/components/todo/Todo.components.jsx
+++ b/src/components/todo/Todo.components.jsx
@@ -5,7 +5,6 @@ import TodoHeader from "./TodoHeader.components";
 import TodoPlan from "./TodoPlan.components";
 import TodoMy from "./TodoMy.components";
 import EditFooter from "./EditFooter.components";
-import styled from "styled-components";
 import LoadingScreen from "../globalcomponents/Loading.components";
 
 function Todo() {
@@ -93,7 +92,7 @@ function Todo() {
   if (error) return <div>에러가 발생했습니다</div>;
 
   return (
-    <Container>
+    <>
       <TodoHeader
         selectedDate={selectedDate}
         setSelectedDate={setSelectedDate}
@@ -140,18 +139,8 @@ function Todo() {
           setUpdateMy={setUpdateMy}
         />
       )}
-    </Container>
+    </>
   );
 }
 
 export default Todo;
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  background-color: #fbfbfb;
-  position: relative;
-  height: 100%;
-`;

--- a/src/components/todo/TodoHeader.components.jsx
+++ b/src/components/todo/TodoHeader.components.jsx
@@ -2,6 +2,7 @@ import Calendar from "./Calendar.components";
 import { Link } from "react-router-dom";
 import { Button } from "antd";
 import styled from "styled-components";
+import WeekCalendar from "./WeekCalendar.components";
 
 function TodoHeader({
   selectedDate,
@@ -25,6 +26,11 @@ function TodoHeader({
           <StyledButton>MY PLAN</StyledButton>
         </Link>
       </UpperHeader>
+
+      <WeekCalendar
+        selectedDate={selectedDate}
+        setSelectedDate={setSelectedDate}
+      />
 
       <LowerHeader>
         {linkText.map((item, i) => (
@@ -67,7 +73,6 @@ const HeaderContainer = styled.div`
   z-index: 999;
   width: 100%;
   background-color: #fbfbfb;
-  height: 90px;
 `;
 
 const UpperHeader = styled.div`

--- a/src/components/todo/TodoHeader.components.jsx
+++ b/src/components/todo/TodoHeader.components.jsx
@@ -59,22 +59,27 @@ function TodoHeader({
 export default TodoHeader;
 
 const HeaderContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   position: fixed;
   top: 0;
   z-index: 999;
-  width: 327px;
+  width: 100%;
   background-color: #fbfbfb;
   height: 110px;
 `;
 
 const UpperHeader = styled.div`
   display: flex;
+  width: 327px;
   justify-content: space-between;
   align-items: center;
 `;
 
 const LowerHeader = styled.div`
   display: flex;
+  width: 327px;
   position: relative;
 `;
 

--- a/src/components/todo/TodoHeader.components.jsx
+++ b/src/components/todo/TodoHeader.components.jsx
@@ -67,7 +67,7 @@ const HeaderContainer = styled.div`
   z-index: 999;
   width: 100%;
   background-color: #fbfbfb;
-  height: 110px;
+  height: 90px;
 `;
 
 const UpperHeader = styled.div`

--- a/src/components/todo/TodoMy.components.jsx
+++ b/src/components/todo/TodoMy.components.jsx
@@ -52,7 +52,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 90px;
+  margin-top: 130px;
   margin-bottom: 95px;
   width: 100%;
   overflow-y: scroll;

--- a/src/components/todo/TodoMy.components.jsx
+++ b/src/components/todo/TodoMy.components.jsx
@@ -54,7 +54,7 @@ const Container = styled.div`
   align-items: center;
   margin-top: 110px;
   margin-bottom: 95px;
-  width: 327px;
+  width: 100%;
   overflow-y: scroll;
   font-family: "PretendardSemiBold";
 `;

--- a/src/components/todo/TodoMy.components.jsx
+++ b/src/components/todo/TodoMy.components.jsx
@@ -17,7 +17,7 @@ function TodoMy({
   const noTodoImg = (
     <img
       src={constants.NO_TODO_IMG}
-      style={{ width: "80%", marginTop: "140px" }}
+      style={{ width: "260px", marginTop: "140px" }}
     />
   );
 

--- a/src/components/todo/TodoMy.components.jsx
+++ b/src/components/todo/TodoMy.components.jsx
@@ -52,7 +52,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 110px;
+  margin-top: 90px;
   margin-bottom: 95px;
   width: 100%;
   overflow-y: scroll;

--- a/src/components/todo/TodoPlan.components.jsx
+++ b/src/components/todo/TodoPlan.components.jsx
@@ -49,7 +49,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 90px;
+  margin-top: 130px;
   margin-bottom: 90px;
   width: 100%;
   overflow-y: scroll;

--- a/src/components/todo/TodoPlan.components.jsx
+++ b/src/components/todo/TodoPlan.components.jsx
@@ -16,7 +16,7 @@ function TodoPlan({
   const planExist = planData?.length;
   const noPlanImg = (
     <img
-      style={{ width: "80%", marginTop: "50px" }}
+      style={{ width: "240px", marginTop: "50px" }}
       src={constants.NO_PLAN_IMG}
       onClick={() => {
         navigate("/planmarket");

--- a/src/components/todo/TodoPlan.components.jsx
+++ b/src/components/todo/TodoPlan.components.jsx
@@ -51,7 +51,7 @@ const Container = styled.div`
   align-items: center;
   margin-top: 110px;
   margin-bottom: 90px;
-  width: 327px;
+  width: 100%;
   overflow-y: scroll;
   font-family: "PretendardSemiBold";
 `;

--- a/src/components/todo/TodoPlan.components.jsx
+++ b/src/components/todo/TodoPlan.components.jsx
@@ -49,7 +49,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 110px;
+  margin-top: 90px;
   margin-bottom: 90px;
   width: 100%;
   overflow-y: scroll;

--- a/src/components/todo/WeekCalendar.components.jsx
+++ b/src/components/todo/WeekCalendar.components.jsx
@@ -1,0 +1,83 @@
+import {
+  format,
+  lastDayOfWeek,
+  startOfWeek,
+  eachDayOfInterval,
+  isSameDay,
+  isSunday,
+  isSaturday,
+  isWeekend
+} from "date-fns";
+import styled from "styled-components";
+
+function WeekCalendar({ selectedDate, setSelectedDate }) {
+  const endOfWeek = lastDayOfWeek(selectedDate);
+  const firstOfWeek = startOfWeek(selectedDate);
+  const weekDays = eachDayOfInterval({
+    start: firstOfWeek,
+    end: endOfWeek,
+  });
+
+  return (
+    <Calendar>
+      {weekDays.map((date, i) => (
+        <Day
+          onClick={() => setSelectedDate(date)}
+          key={i}
+          selected={isSameDay(date, selectedDate)}
+          today={isSameDay(date, new Date())}
+          isWeekend={isWeekend(date)}
+        >
+          <span>{format(date, "d")}</span>
+        </Day>
+      ))}
+    </Calendar>
+  );
+}
+
+export default WeekCalendar;
+
+const Calendar = styled.div`
+  display: flex;
+  width: 327px;
+  justify-content: space-between;
+  background: #fbfbfb;
+  margin-bottom: 10px;
+`;
+
+const Day = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  padding: 5px;
+  width: 30px;
+  height: 30px;
+  text-align: center;
+  color: ${(props) => (props.today ? "#7965F4" : "black")};
+  color: ${props => props.isWeekend && "#929292"};
+
+  span {
+    font-size: 16px;
+    line-height: 16px;
+    font-weight: 700;
+    font-family: "PretendardRegular";
+    position: relative;
+    z-index: 2;
+  }
+
+  ${(props) =>
+    props.selected &&
+    `::after {
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    content: "";
+    background-color: #e1dcfe;
+    width: 30px;
+    height: 30px;
+    border-radius: 100%;
+    z-index: 1;
+  }`}
+`;

--- a/src/components/todo/detail/TodoDetail.components.jsx
+++ b/src/components/todo/detail/TodoDetail.components.jsx
@@ -3,8 +3,8 @@ import { useParams, useNavigate } from "react-router-dom";
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import styled from "styled-components";
 import axios from "axios";
-import BottomNavBar from "../globalcomponents/BottomNavBar.components";
-import LoadingScreen from "../globalcomponents/Loading.components";
+import BottomNavBar from "../../globalcomponents/BottomNavBar.components";
+import LoadingScreen from "../../globalcomponents/Loading.components";
 
 function TodoDetail() {
   const accessToken = sessionStorage.getItem("access");

--- a/src/components/todo/plan/PlanDetail.components.jsx
+++ b/src/components/todo/plan/PlanDetail.components.jsx
@@ -3,9 +3,9 @@ import { useNavigate, useParams, useLocation } from "react-router-dom";
 import axios from "axios";
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import styled from "styled-components";
-import PlanTodo from "./PlanTodo.components";
-import BottomNavBar from "../globalcomponents/BottomNavBar.components";
-import EditFooter from "./EditFooter.components";
+import PlanTodo from "../PlanTodo.components";
+import BottomNavBar from "../../globalcomponents/BottomNavBar.components";
+import EditFooter from "../EditFooter.components";
 
 function PlanDetail() {
   const navigate = useNavigate();


### PR DESCRIPTION
# 1. 스크롤 영역 수정
Proposal 페이지에 스크롤 영역 width를 100%로 한 것과 마찬가지로, PlanMarket, Todo, MyPlan 페이지의 스크롤 영역 width를 모두 100%가 되도록 했습니다. 
수정하면서 기존에 width 327px짜리 컴포넌트로 한번 더 감쌌던 것을 `<div class="app">`안 에 바로 나타나도록 변경했습니다.

# 2. 헤더 수정
헤더가 `position: fixed`로 되어있지 않았던 헤더를 모두 fixed로 수정했습니다. 

# 3. WeekCalendar를 추가했습니다.
명성이형 요청에 따라 Todo 페이지 헤더에 WeekCalendar를 추가했습니다. `date-fns`를 이용해서 구현했는데 지금 쓰고있는 MuiDatePicker도 이걸로 구현되어있는거 보니까, 캘린더를 직접 구현해도 될 것 같더라고요 리소스는 좀 들겠지만. 
js에서 Date 객체 다루는데 많이 사용하는 것 같으니까 준열시도 사용법 익혀두면 좋을 것 같습니다.
https://date-fns.org/

# 4. Todo 디렉토리 구조 변경
Todo 페이지에서 이동가능한 페이지를 따로 디렉토리로 뺐습니다. url따라서 디렉토리명을 설정했습니다.




### ps. 마이플랜 쪽 css 수정하느라 컨플릭트 날 수 도 있을 것 같습니다. 유의해주세요