### PR TITLE
이슈 수정, css 수정

### DIFF
--- a/public/images/detail.svg
+++ b/public/images/detail.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.22217 4.44434L10.2222 8.44434L6.22217 12.4443" stroke="#929292" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/todo/Plan.components.jsx
+++ b/src/components/todo/Plan.components.jsx
@@ -63,7 +63,7 @@ const Title = styled.span`
   font-size: 16px;
   font-family: "PretendardRegular";
   font-weight: 600;
-  padding: 0 12px;
+  padding-right: 12px;
 `;
 
 const Achievement = styled.span`

--- a/src/components/todo/PlanTodo.components.jsx
+++ b/src/components/todo/PlanTodo.components.jsx
@@ -70,7 +70,7 @@ function PlanTodo({
 export default PlanTodo;
 
 const Container = styled.div`
-  padding: 5px 12px;
+  padding: 5px 0;
   height: 36px;
   margin-top: 5px;
   margin-left: 0 !important;
@@ -115,6 +115,6 @@ const StyledCheckbox = styled(Checkbox)`
 `;
 
 const DetailIcon = styled.img`
-  height: 12px;
+  height: 16px;
   margin-left: auto;
 `;

--- a/src/components/todo/WeekCalendar.components.jsx
+++ b/src/components/todo/WeekCalendar.components.jsx
@@ -54,8 +54,9 @@ const Day = styled.div`
   width: 30px;
   height: 30px;
   text-align: center;
-  color: ${(props) => (props.today ? "#7965F4" : "black")};
+  color: black;
   color: ${props => props.isWeekend && "#929292"};
+  color: ${(props) => (props.today && "#7965F4")};
 
   span {
     font-size: 16px;

--- a/src/components/todo/detail/TodoDetail.components.jsx
+++ b/src/components/todo/detail/TodoDetail.components.jsx
@@ -45,7 +45,7 @@ function TodoDetail() {
   if (!imgUrl) return null;
   if (loading) return <LoadingScreen />;
   return (
-    <Container>
+    <>
       <Header>
         <FlexBox>
           <ArrowBackIosIcon
@@ -61,26 +61,16 @@ function TodoDetail() {
         </FlexBox>
       </Header>
 
-      <div style={{ overflowY: "scroll", paddingTop: "28px" }}>
-        <img src={imgUrl} style={{ width: "327px", marginBottom: "120px" }} />
-      </div>
+      <Content>
+        <MainImg src={imgUrl} />
+      </Content>
 
       <BottomNavBar current="TODO" />
-    </Container>
+    </>
   );
 }
 
 export default TodoDetail;
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  background-color: #fbfbfb;
-  position: relative;
-  height: 100%;
-`;
 
 const FlexBox = styled.div`
   display: flex;
@@ -93,7 +83,7 @@ const Header = styled.div`
   background: #ffffff;
   width: 100vw;
   display: flex;
-  position: relative;
+  position: fixed;
   justify-content: center;
   height: 56px;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.08);
@@ -105,4 +95,19 @@ const Title = styled.div`
   font-size: 18px;
   height: 56px;
   line-height: 56px;
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  margin-top: 56px;
+  padding-top: 26px;
+  overflow-y: scroll;
+`;
+
+const MainImg = styled.img`
+  width: 327px;
+  margin-bottom: 120px;
 `;

--- a/src/components/todo/plan/PlanDetail.components.jsx
+++ b/src/components/todo/plan/PlanDetail.components.jsx
@@ -65,7 +65,7 @@ function PlanDetail() {
   };
 
   return (
-    <Container>
+    <>
       <Header>
         <FlexBox>
           <ArrowBackIosIcon
@@ -149,29 +149,19 @@ function PlanDetail() {
       ) : (
         <BottomNavBar current="TODO" />
       )}
-    </Container>
+    </>
   );
 }
 
 export default PlanDetail;
 
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  background-color: #fbfbfb;
-  position: relative;
-  height: 100%;
-`;
-
 const TodoContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 10px;
+  margin-top: 100px;
   margin-bottom: 100px;
-  width: 327px;
+  width: 100%;
   overflow-y: scroll;
   font-family: "PretendardSemiBold";
 `;
@@ -187,7 +177,7 @@ const Header = styled.div`
   background: #fbfbfb;
   width: 100vw;
   display: flex;
-  position: relative;
+  position: fixed;
   align-items: center;
   flex-direction: column;
 `;
@@ -257,9 +247,10 @@ const PlanHeader = styled.div`
   align-items: center;
   margin-bottom: 10px;
 `;
+
 const Date = styled.span`
   font-size: 16px;
   font-family: "PretendardRegular";
   font-weight: 600;
-  padding: 0 12px;
+  padding: 0;
 `;

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,7 +8,7 @@ const constants = {
   NO_TODO_IMG: "/images/my.png",
   DO_TOMORROW: "/images/do_tomorrow.svg",
   DELETE: "/images/delete.svg",
-  DETAIL_ICON: "/images/detail.png",
+  DETAIL_ICON: "/images/detail.svg",
   PROPOSAL: "/images/proposal.svg"
 };
 


### PR DESCRIPTION
### 1. 플랜 부분 제목이 오른쪽으로 치우쳐보이는 것 수정

### 2. [QA 13] WeekCalendar에서 주말 폰트 색상이 정상적으로 보이도록 수정

### 3. TodoDetail, PlanDetail 페이지도 헤더를 fixed로 바꾸고 스크롤 영역 width를 100%로 조정했습니다.