### PR TITLE
로그인 로직 수정, Sheet UX 수정, PlanMarketDetail 변경, PlanDetail 변경

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import MyPlan from "./components/myplan/MyPlan.components";
 import TodoDetail from "./components/todo/detail/TodoDetail.components";
 import PlanDetail from "./components/todo/plan/PlanDetail.components";
 import PlanMarket from "./components/planmarket/PlanMarket.components";
+import PlanMarketDetail from "./components/planmarket/PlanMarketDetailOld.components";
 import Proposal from "./components/proposal/Proposal.components";
 import KakaoSocial from "./components/social/KakaoSocial.components";
 import GoogleSocial from "./components/social/GoogleSocial.components";
@@ -39,6 +40,7 @@ function App() {
         <Route path="/planmarket" element={<PlanMarket />} />
         <Route path="/proposal" element={<Proposal />} />
 
+        <Route path="/planmarket/plan/:id" element={<PlanMarketDetail />} />
         <Route path="/main/viewtemplate/:id" element={<ViewTemplate />} />
         <Route path="/main/searchtemplate" element={<SearchTemplate />} />
 

--- a/src/components/admin/admin.components.jsx
+++ b/src/components/admin/admin.components.jsx
@@ -25,7 +25,7 @@ function Admin() {
       .then((response) => {
         const data = response.data;
         sessionStorage.setItem("access", data.django_token.access);
-        sessionStorage.setItem("refresh", data.django_token.refresh);
+        localStorage.setItem("refresh", data.django_token.refresh);
         navigate("/todo");
       })
       .catch((error) => {

--- a/src/components/globalcomponents/ErrorHandler.components.jsx
+++ b/src/components/globalcomponents/ErrorHandler.components.jsx
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import axios from "axios";
+import { useNavigate } from "react-router-dom";
+
+function ErrorHandler({ error }) {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (error.response.status === 401) {
+      axios
+        .post("https://myplanit.link/api/token/verify", {
+          token: localStorage.getItem("refresh"),
+        })
+        .then((res) => {
+          if (res.status == 200) {
+            axios
+              .post("https://myplanit.link/api/token/refresh", {
+                refresh: localStorage.getItem("refresh"),
+              })
+              .then((res) => {
+                const access = res.data.access;
+                sessionStorage.setItem("access", access);
+                navigate(-1);
+              });
+          }
+        })
+        .catch((err) => {
+          localStorage.removeItem("refresh");
+          navigate('/');
+        });
+    }
+  });
+
+  return <div>{error.massage}</div>;
+}
+
+export default ErrorHandler;

--- a/src/components/login/LoginPage.components.jsx
+++ b/src/components/login/LoginPage.components.jsx
@@ -1,7 +1,12 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import axios from 'axios';
 import constants from "../../constants";
 import * as Styled from "./LoginPage.style";
 
 function LoginPage() {
+  const navigate = useNavigate();
+
   const kakaoLogin = () => {
     window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.REACT_APP_KAKAO_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_KAKAO_REDIRECT_URI}&response_type=code`;
   };
@@ -9,6 +14,26 @@ function LoginPage() {
   const googleLogin = () => {
     window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.REACT_APP_GOOGLE_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_GOOGLE_REDIRECT_URI}&response_type=code&scope=https://www.googleapis.com/auth/userinfo.profile`;
   };
+
+  useEffect(() => {
+    const token = localStorage.getItem("refresh");
+    if (token) {
+      axios.post('https://myplanit.link/api/token/verify', {
+        token,
+      })
+      .then((res) => {
+        if (res.status === 200) {
+          navigate("/todo");
+        }
+      })
+      .catch((err) => {
+        if (err.response.status === 401) {
+          localStorage.removeItem("refresh");
+        }
+      })
+    }
+  }, [])
+  
 
   return (
     <Styled.Container>

--- a/src/components/myplan/MyPlan.components.jsx
+++ b/src/components/myplan/MyPlan.components.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import axios from "axios";
-import { Loading } from "@nextui-org/react";
 import BottomNavBar from "../globalcomponents/BottomNavBar.components";
 import MyPlanHeader from "./MyPlanHeader.components";
 import MyPlanContent from "./MyPlanContent.components";
@@ -53,7 +52,7 @@ function MyPlan() {
             Authorization: `Bearer ${accessToken}`,
           },
         });
-        console.log(response);
+        // console.log(response);
         setBuyPlans(response.data.buy_plans ? response.data.buy_plans : []);
         setBuyLength(
           response.data.buy_plans ? response.data.buy_plans.length : 0

--- a/src/components/myplan/MyPlanHeader.components.jsx
+++ b/src/components/myplan/MyPlanHeader.components.jsx
@@ -1,90 +1,60 @@
-import React from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
-import styled from "styled-components";
+import * as Styled from "./MyPlanHeader.style";
+import Sheet from "react-modal-sheet";
 
 function MyPlanHeader({ current, setCurrent, buyLength, registerLength }) {
   const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const logout = () => {
+    localStorage.removeItem("refresh");
+    navigate("/");
+  };
+
   return (
-    <Header>
-      <UpperHeader>
-        <ArrowBackIosIcon
-          style={{ height: 56, color: "black", position: "absolute", left: 0 }}
-          onClick={() => navigate(-1)}
-        />
-        <Title>MY PLAN</Title>
-      </UpperHeader>
-      <LowerHeader>
-        <LinkButton
-          selected={current === "BUY"}
-          onClick={() => setCurrent("BUY")}
-        >
-          {"구매 플랜(" + buyLength + ")"}
-        </LinkButton>
-        <LinkButton
-          selected={current === "REGISTER"}
-          onClick={() => setCurrent("REGISTER")}
-        >
-          {"이용 중(" + registerLength + ")"}
-        </LinkButton>
-      </LowerHeader>
-    </Header>
+    <>
+      <Styled.Header>
+        <Styled.UpperHeader>
+          <Styled.BackButton onClick={() => navigate(-1)} />
+          <Styled.Title>MY PLAN</Styled.Title>
+          <Styled.LogoutBtn onClick={() => setOpen(true)}>
+            로그아웃
+          </Styled.LogoutBtn>
+        </Styled.UpperHeader>
+
+        <Styled.LowerHeader>
+          <Styled.LinkButton
+            selected={current === "BUY"}
+            onClick={() => setCurrent("BUY")}
+          >
+            {`구매 플랜(${buyLength})`}
+          </Styled.LinkButton>
+          <Styled.LinkButton
+            selected={current === "REGISTER"}
+            onClick={() => setCurrent("REGISTER")}
+          >
+            {`이용 중(${registerLength})`}
+          </Styled.LinkButton>
+        </Styled.LowerHeader>
+      </Styled.Header>
+
+      <Styled.StyledSheet isOpen={open} snapPoints={[200]}>
+        <Sheet.Container>
+          <Sheet.Header />
+
+          <Sheet.Content>
+            <Styled.Text>로그아웃 할까요?</Styled.Text>
+            <Styled.Button onClick={logout}>네</Styled.Button>
+            <Styled.Button cancel onClick={() => setOpen(false)}>
+              아니오
+            </Styled.Button>
+          </Sheet.Content>
+        </Sheet.Container>
+
+        <Sheet.Backdrop onTap={() => setOpen(false)} />
+      </Styled.StyledSheet>
+    </>
   );
 }
 
 export default MyPlanHeader;
-
-const Header = styled.div`
-  position: fixed;
-  z-index: 10;
-  width: 100%;
-  background: #fbfbfb;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`
-
-const UpperHeader = styled.div`
-  background: #fbfbfb;
-  width: 327px;
-  display: flex;
-  position: relative;
-  justify-content: center;
-  height: 56px;
-`;
-
-const LowerHeader = styled.div`
-  display: flex;
-  width: 327px;
-  margin: 8px;
-  font-size: 16px;
-  font-weight: bold;
-  margin-left: 10;
-`;
-
-const Title = styled.div`
-  font-family: "SFProDisplay";
-  font-weight: 510;
-  font-size: 18px;
-  height: 56px;
-  line-height: 56px;
-`;
-
-const LinkButton = styled.button`
-  box-sizing: border-box;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: 0px;
-  background-color: #fbfbfb;
-  border-radius: 0;
-  border-width: 0px 0px 0px;
-  font-family: "PretendardMedium";
-  font-size: 16px;
-  margin-right: 15px;
-  padding: 0 0 1px;
-
-  color: ${(props) => (props.selected ? "black" : "#C4C4C4")};
-  border-bottom: ${(props) => (props.selected ? "2px solid #8977f7" : "none")};
-  padding-bottom: ${(props) => (props.selected ? "2px" : "4px")};
-`;

--- a/src/components/myplan/MyPlanHeader.components.jsx
+++ b/src/components/myplan/MyPlanHeader.components.jsx
@@ -8,6 +8,7 @@ function MyPlanHeader({ current, setCurrent, buyLength, registerLength }) {
   const [open, setOpen] = useState(false);
   const logout = () => {
     localStorage.removeItem("refresh");
+    sessionStorage.removeItem("access");
     navigate("/");
   };
 

--- a/src/components/myplan/MyPlanHeader.style.js
+++ b/src/components/myplan/MyPlanHeader.style.js
@@ -1,0 +1,114 @@
+import styled from "styled-components";
+import Sheet from "react-modal-sheet";
+import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
+
+export const Header = styled.div`
+  position: fixed;
+  z-index: 10;
+  width: 100%;
+  background: #fbfbfb;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const UpperHeader = styled.div`
+  background: #fbfbfb;
+  width: 327px;
+  display: flex;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  height: 56px;
+`;
+
+export const BackButton = styled(ArrowBackIosIcon)`
+    height: 56px;
+    position: absolute;
+    left: 0;
+    color: black;
+`
+
+export const LowerHeader = styled.div`
+  display: flex;
+  width: 327px;
+  margin: 8px;
+  font-size: 16px;
+  font-weight: bold;
+  margin-left: 10;
+`;
+
+export const Title = styled.div`
+  font-family: "SFProDisplay";
+  font-weight: 510;
+  font-size: 18px;
+  height: 56px;
+  line-height: 56px;
+`;
+
+export const LinkButton = styled.button`
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 0px;
+  background-color: #fbfbfb;
+  border-radius: 0;
+  border-width: 0px 0px 0px;
+  font-family: "PretendardMedium";
+  font-size: 16px;
+  margin-right: 15px;
+  padding: 0 0 1px;
+
+  color: ${(props) => (props.selected ? "black" : "#C4C4C4")};
+  border-bottom: ${(props) => (props.selected ? "2px solid #8977f7" : "none")};
+  padding-bottom: ${(props) => (props.selected ? "2px" : "4px")};
+`;
+
+export const LogoutBtn = styled.button`
+  position: absolute;
+  right: 0px;
+  background: #ffffff;
+  box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.08);
+  border: none;
+  border-radius: 4px;
+  width: 64px;
+  height: 24px;
+  font-size: 10px;
+  font-family: "PretendardMedium";
+`;
+
+export const StyledSheet = styled(Sheet)`
+  .react-modal-sheet-backdrop {
+    border: none;
+  }
+
+  .react-modal-sheet-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+`;
+
+export const Text = styled.span`
+  font-size: 16px;
+  font-family: "PretendardMedium";
+  margin-bottom: 24px;
+`;
+
+export const Button = styled.button`
+  border: none;
+  border-radius: 4px;
+  background-color: #7965F4;
+  color: #ffffff;
+  width: 327px;
+  height: 48px;
+  margin-bottom: 12px;
+
+  ${(props) =>
+    props.cancel &&
+    `
+    background-color: #f4f4f4;
+    color: #000000;
+  `}
+`;

--- a/src/components/myplan/PlanSheet.components.jsx
+++ b/src/components/myplan/PlanSheet.components.jsx
@@ -62,104 +62,80 @@ function PlanSheet({
       });
   };
   return (
-    <span>
-      {register && (
-        <Sheet
-          isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
-          snapPoints={[300]}
-        >
-          <Sheet.Container>
-            <Sheet.Header />
-            <Sheet.Content
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-              }}
-            >
-              <Title>{title}</Title>
-              <Author>
+    <>
+      <StyledSheet
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        snapPoints={[300]}
+      >
+        <Sheet.Container>
+          <Sheet.Header />
+          <Sheet.Content>
+            <Title>{title}</Title>
+            <Author>
+              {register && (
                 <Text color="black">
                   {date[0]} ~ {date[1]}
                 </Text>
-                <Text color="#929292">{writer_name}</Text>
-              </Author>
-              <StyledButton
-                onClick={() => {
-                  navigate("../todo/plan/" + planId, {
-                    state: { title: title },
-                  });
-                }}
-                underline
-              >
-                <Text>투두 모아보기</Text>
-              </StyledButton>
-              <StyledButton
-                onClick={() => navigate("../main/viewtemplate/" + planId)}
-                underline
-              >
-                <Text>플랜 마켓 가기</Text>
-              </StyledButton>
-              <StyledButton onClick={deletePlan}>
-                <Text color="red">투두 리스트에서 제거하기</Text>
-              </StyledButton>
-            </Sheet.Content>
-          </Sheet.Container>
+              )}
+              <Text color="#929292">{writer_name}</Text>
+            </Author>
 
-          <Sheet.Backdrop />
-        </Sheet>
-      )}
-
-      {buy && (
-        <Sheet
-          isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
-          snapPoints={[300]}
-        >
-          <Sheet.Container>
-            <Sheet.Header />
-            <Sheet.Content
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-              }}
-            >
-              <Title>{title}</Title>
-              <Text color="#929292" style={{ width: "327px" }}>
-                {writer_name}
-              </Text>
-              {}
+            {buy && (
               <StyledButton onClick={registerPlan} underline>
                 <Text>투두 등록하기</Text>
               </StyledButton>
-              <StyledButton
-                onClick={() => {
-                  navigate("../todo/plan/" + planId, {
-                    state: { title: title },
-                  });
-                }}
-                underline
-              >
-                <Text>투두 모아보기</Text>
-              </StyledButton>
-              <StyledButton
-                onClick={() => navigate("../main/viewtemplate/" + planId)}
-              >
-                <Text>플랜 마켓 가기</Text>
-              </StyledButton>
-            </Sheet.Content>
-          </Sheet.Container>
+            )}
 
-          <Sheet.Backdrop />
-        </Sheet>
-      )}
-    </span>
+            <StyledButton
+              onClick={() => {
+                navigate("../todo/plan/" + planId, {
+                  state: { title: title },
+                });
+              }}
+              underline
+            >
+              <Text>투두 모아보기</Text>
+            </StyledButton>
+
+            <StyledButton
+              onClick={() => navigate("../main/viewtemplate/" + planId)}
+              underline={register}
+            >
+              <Text>플랜 마켓 가기</Text>
+            </StyledButton>
+
+            {register && (
+              <StyledButton onClick={deletePlan}>
+                <Text color="red">투두 리스트에서 제거하기</Text>
+              </StyledButton>
+            )}
+          </Sheet.Content>
+        </Sheet.Container>
+
+        <Sheet.Backdrop
+          onTap={() => {
+            setIsOpen(false);
+          }}
+        />
+      </StyledSheet>
+    </>
   );
 }
 
 export default PlanSheet;
+
+const StyledSheet = styled(Sheet)`
+  .react-modal-sheet-backdrop {
+    border: none;
+  }
+
+  .react-modal-sheet-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+`;
 
 const Title = styled.div`
   font-family: "PretendardMedium";

--- a/src/components/myplan/PlanSheet.components.jsx
+++ b/src/components/myplan/PlanSheet.components.jsx
@@ -99,7 +99,7 @@ function PlanSheet({
             </StyledButton>
 
             <StyledButton
-              onClick={() => navigate("../main/viewtemplate/" + planId)}
+              onClick={() => navigate("/planmarket/plan/" + planId)}
               underline={register}
             >
               <Text>플랜 마켓 가기</Text>

--- a/src/components/planmarket/PlanMarket.components.jsx
+++ b/src/components/planmarket/PlanMarket.components.jsx
@@ -11,7 +11,7 @@ function PlanMarket() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    const fetchUsers = async () => {
+    const fetchPlans = async () => {
       try {
         setLoading(true);
         const response = await axios.get("https://myplanit.link/plans");
@@ -23,7 +23,7 @@ function PlanMarket() {
       setLoading(false);
     };
 
-    fetchUsers();
+    fetchPlans();
   }, []);
 
   if (loading)

--- a/src/components/planmarket/PlanMarketContent.components.jsx
+++ b/src/components/planmarket/PlanMarketContent.components.jsx
@@ -16,7 +16,7 @@ function PlanMarketContent({ plans }) {
           writer_intro={plan.writer_intro}
           desc={plan.desc}
           tags={plan.tags}
-          onClick={() => navigate("../main/viewtemplate/" + plan.id)}
+          onClick={() => navigate("/planmarket/plan/" + plan.id)}
         />
       ))}
     </Container>

--- a/src/components/planmarket/PlanMarketDetail.components.jsx
+++ b/src/components/planmarket/PlanMarketDetail.components.jsx
@@ -1,22 +1,70 @@
 import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
 import styled from "styled-components";
 
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+
 function PlanMarketDetail() {
+  const { id } = useParams();
+  const navigate = useNavigate();
   const [plan, setPlan] = useState([]);
-  const fetchUsers = async () => {
+  const [open, setOpen] = useState(false);
+  const fetchPlan = async () => {
     try {
-      const response = await axios.get("https://myplanit.link/plans");
-      setPlan(response.data.Growth[0]);
+      const response = await axios.get("https://myplanit.link/plans/" + id);
+      setPlan(response.data);
     } catch (e) {
       console.log(e);
     }
   };
+
   useEffect(() => {
-    fetchUsers();
+    fetchPlan();
   }, []);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+  const accessToken = sessionStorage.getItem("access");
+  const handleClose = (event, reason) => {
+    if (reason && reason == "backdropClick") return;
+    axios
+      .all([
+        axios.post(
+          "https://myplanit.link/plans/" + id + "/buy",
+          {},
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        ),
+        axios.post(
+          "https://myplanit.link/myplans/" + id + "/register",
+          {},
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        ),
+      ])
+      .then((response) => {
+        navigate("/todo");
+      });
+    setOpen(false);
+  };
+
   return (
-    <Container>
+    <>
       <MainImage src={plan.intro_img_url} />
       <PlanInfo>
         <Title>{plan.name}</Title>
@@ -25,9 +73,13 @@ function PlanMarketDetail() {
             <Tag key={i}>{tag}</Tag>
           ))}
           <Dot />
-          <Text color="#929292" size="12px">기간 4주</Text>
+          <Text color="#929292" size="12px">
+            기간 4주
+          </Text>
           <Dot />
-          <Text color="#929292" size="12px">무료</Text>
+          <Text color="#929292" size="12px">
+            무료
+          </Text>
         </Info>
       </PlanInfo>
 
@@ -40,22 +92,18 @@ function PlanMarketDetail() {
       </ProfileContainer>
 
       <PlanIntro>
-        <Text size="16px" font="PretendardMideum" margin="20px">플랜 소개</Text>
+        <Text size="16px" font="PretendardMideum" margin="20px">
+          플랜 소개
+        </Text>
       </PlanIntro>
-    </Container>
+    </>
   );
 }
 
 export default PlanMarketDetail;
 
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  background-color: #fbfbfb;
-  position: relative;
-  height: 100vh;
+const MainImg = styled.img`
+  width: 100%;
 `;
 
 const Dot = styled.div`
@@ -67,11 +115,12 @@ const Dot = styled.div`
 `;
 
 const Text = styled.div`
-  color: ${props => props.color || "#000000"};
-  font-family: ${props => props.font || "PretendardRegular"};
-  font-size: ${props => props.size};
-  margin-bottom: ${props => props.margin};
+  color: ${(props) => props.color || "#000000"};
+  font-family: ${(props) => props.font || "PretendardRegular"};
+  font-size: ${(props) => props.size};
+  margin-bottom: ${(props) => props.margin};
 `;
+
 
 const MainImage = styled.img`
   width: 375px;
@@ -144,7 +193,7 @@ const ProfileText = styled.div`
 `;
 
 const PlanIntro = styled.div`
-    display: flex;
-    flex-direction: column;
-    width: 327px;
-`
+  display: flex;
+  flex-direction: column;
+  width: 327px;
+`;

--- a/src/components/planmarket/PlanMarketDetailOld.components.jsx
+++ b/src/components/planmarket/PlanMarketDetailOld.components.jsx
@@ -1,0 +1,207 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import axios from "axios";
+import styled from "styled-components";
+import LoadingScreen from "../globalcomponents/Loading.components";
+
+import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+
+function PlanMarketDetail() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [plan, setPlan] = useState([]);
+  const [isRegistered, setIsRegistered] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [open, setOpen] = useState(false);
+  const accessToken = sessionStorage.getItem("access");
+  const fetchPlan = async () => {
+    setLoading(true);
+    try {
+      const response = await axios.get("https://myplanit.link/plans/" + id, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      setPlan(response.data.Plan);
+      setIsRegistered(response.data.own_flag);
+    } catch (e) {
+      setError(e);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchPlan();
+  }, []);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const buyPlan = () => {
+    axios
+      .all([
+        axios.post(
+          `https://myplanit.link/plans/${id}/buy`,
+          {},
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        ),
+        axios.post(
+          `https://myplanit.link/myplans/${id}/register`,
+          {},
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        ),
+      ])
+      .then(() => {
+        navigate("/todo");
+      });
+  };
+
+  if (loading) return <LoadingScreen />;
+  if (error) return <div>에러가 발생했습니다</div>;
+
+  return (
+    <>
+      <MainImg src={plan.main_img_url} />
+
+      <StyledArrowButton onClick={() => navigate(-1)} />
+
+      <Footer>
+        {isRegistered ? (
+          <BuyButton disabled>구매한 플랜입니다</BuyButton>
+        ) : (
+          <BuyButton onClick={handleClickOpen}>지금 바로 구매하기</BuyButton>
+        )}
+      </Footer>
+
+      <StyledDialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogImg src="/images/celebrate.png" />
+
+        <DialogTitle
+          id="alert-dialog-title"
+        >
+          {"짠! 지금은 무료체험 기간이에요."}
+        </DialogTitle>
+
+        <DialogContent>
+          <DialogContentText
+            id="alert-dialog-description"
+          >
+            선택하신 플랜을 무료로 사용해보세요!
+          </DialogContentText>
+        </DialogContent>
+
+        <DialogActions style={{ display: "flex", flexDirection: "column" }}>
+          <DialogButton width="240px" height="52px" onClick={buyPlan}>
+            내 투두에 추가하기
+          </DialogButton>
+        </DialogActions>
+      </StyledDialog>
+    </>
+  );
+}
+
+export default PlanMarketDetail;
+
+const MainImg = styled.img`
+  width: 100%;
+`;
+
+const Footer = styled.div`
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  filter: drop-shadow(0px -3px 4px rgba(0, 0, 0, 0.04));
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #ffffff;
+  height: 85px;
+`;
+
+const StyledArrowButton = styled(ArrowBackIosIcon)`
+  color: #7965f4;
+  position: fixed;
+  top: 30px;
+  left: 24px;
+`;
+
+const BuyButton = styled.button`
+  width: 327px;
+  height: 52px;
+  padding: 18px;
+  line-height: 14px;
+  background: #7965f4;
+  border: none;
+  border-radius: 5px;
+  color: #ffffff;
+  font-family: "PretendardMedium";
+
+  ${(props) =>
+    props.disabled &&
+    `
+    background: #c4c4c4;
+    touch-action: none;
+  `}
+`;
+
+const StyledDialog = styled(Dialog)`
+    #alert-dialog-title {
+      font-size: 16px;
+      font-family: "PretendardMedium";
+      padding: 12px;
+      width: 260px;
+      text-align: center;
+    }
+
+    #alert-dialog-description {
+      font-size: 12px;
+      font-family: "PretendardMedium";
+      textAlign: center;
+      color: #929292;
+    }
+`
+
+const DialogButton = styled.button`
+  width: 220px;
+  height: 42px;
+  line-height: 14px;
+  background: #7965f4;
+  border: none;
+  border-radius: 5px;
+  color: #ffffff;
+  font-family: "PretendardMedium";
+  margin-bottom: 10px;
+`;
+
+const DialogImg = styled.img`
+  width: 60px;
+  height: 60px;
+  margin: 40px auto 10px;
+`;

--- a/src/components/social/GoogleSocial.components.jsx
+++ b/src/components/social/GoogleSocial.components.jsx
@@ -14,7 +14,7 @@ function GoogleSocial() {
         const data = response.data;
         const status = response.status;
         sessionStorage.setItem("access", data.django_token.access);
-        sessionStorage.setItem("refresh", data.django_token.refresh);
+        localStorage.setItem("refresh", data.django_token.refresh);
         navigate("/todo");
       })
       .catch((error) => {

--- a/src/components/social/KakaoSocial.components.jsx
+++ b/src/components/social/KakaoSocial.components.jsx
@@ -14,7 +14,7 @@ function KakaoSocial() {
         const data = response.data;
         const status = response.status;
         sessionStorage.setItem("access", data.django_token.access);
-        sessionStorage.setItem("refresh", data.django_token.refresh);
+        localStorage.setItem("refresh", data.django_token.refresh);
         navigate("/todo");
       })
       .catch((error) => {

--- a/src/components/todo/NewMyTodo.components.jsx
+++ b/src/components/todo/NewMyTodo.components.jsx
@@ -49,7 +49,7 @@ function NewMyTodo({ selectedDate, updateMy, setUpdateMy }) {
         icon={<PlusOutlined />}
       />
 
-      <Sheet isOpen={isOpen} onClose={() => setOpen(false)} snapPoints={[250]}>
+      <StyledSheet isOpen={isOpen} onClose={() => setOpen(false)} snapPoints={[250]}>
         <Sheet.Container>
           <Sheet.Header />
           <Sheet.Content>
@@ -67,8 +67,8 @@ function NewMyTodo({ selectedDate, updateMy, setUpdateMy }) {
           </Sheet.Content>
         </Sheet.Container>
 
-        <Sheet.Backdrop />
-      </Sheet>
+        <Sheet.Backdrop onTap={() => setOpen(false)} />
+      </StyledSheet>
     </>
   );
 }
@@ -115,3 +115,9 @@ font-family: "PretendardRegular"
 font-size: 16px;
 color: black;
 `;
+
+const StyledSheet = styled(Sheet)`
+  .react-modal-sheet-backdrop {
+    border: none;
+  }
+`

--- a/src/components/todo/Todo.components.jsx
+++ b/src/components/todo/Todo.components.jsx
@@ -7,6 +7,7 @@ import TodoPlan from "./TodoPlan.components";
 import TodoMy from "./TodoMy.components";
 import EditFooter from "./EditFooter.components";
 import LoadingScreen from "../globalcomponents/Loading.components";
+import ErrorHandle from "../globalcomponents/ErrorHandler.components";
 
 function Todo() {
   const accessToken = sessionStorage.getItem("access");
@@ -22,7 +23,7 @@ function Todo() {
   const [current, setCurrent] = useState("PLAN");
   const [planData, setPlanData] = useState();
   const [myTodoData, setMyTodoData] = useState();
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [edit, setEdit] = useState(false);
   const [delay, setDelay] = useState([]);
@@ -33,8 +34,6 @@ function Todo() {
         .get(
           `https://myplanit.link/todos/plan/${format(selectedDate, "yyyy-MM-dd")}`,
           {
-            Authorization: `Bearer ${accessToken}`,
-            withCredentials: true,
             headers: {
               "Content-Type": "application/json",
               Authorization: `Bearer ${accessToken}`,
@@ -43,10 +42,10 @@ function Todo() {
         )
         .then((response) => {
           setPlanData(Object.entries(response.data));
+          setLoading(false);
         });
     } catch (err) {
       setError(err);
-      console.log(err);
     }
   };
 
@@ -56,8 +55,6 @@ function Todo() {
         .get(
           `https://myplanit.link/todos/my/${format(selectedDate, "yyyy-MM-dd")}`,
           {
-            Authorization: `Bearer ${accessToken}`,
-            withCredentials: true,
             headers: {
               "Content-Type": "application/json",
               Authorization: `Bearer ${accessToken}`,
@@ -66,27 +63,31 @@ function Todo() {
         )
         .then((response) => {
           setMyTodoData(response.data.personal_todos);
+          setLoading(false);
         });
     } catch (err) {
       setError(err);
-      console.log(err);
     }
   };
 
   useEffect(() => {
-    fetchPlan();
-    setEdit(false);
-    setDelay([]);
-  }, [selectedDate, update]);
+    if (current === "PLAN") {
+      fetchPlan();
+      setEdit(false);
+      setDelay([]);
+    }
+  }, [current, selectedDate, update]);
 
   useEffect(() => {
-    fetchMyTodo();
-    setEdit(false);
-    setDelay([]);
-  }, [selectedDate, updateMy]);
+    if (current === "MY") {
+      fetchMyTodo();
+      setEdit(false);
+      setDelay([]);
+    }
+  }, [current, selectedDate, updateMy]);
 
+  if (error) return <ErrorHandle error={error} />
   if (loading) return <LoadingScreen />;
-  if (error) return <div>에러가 발생했습니다</div>;
 
   return (
     <>

--- a/src/components/todo/plan/PlanDetail.components.jsx
+++ b/src/components/todo/plan/PlanDetail.components.jsx
@@ -17,7 +17,7 @@ function PlanDetail() {
   const [delay, setDelay] = useState([]);
   const [update, setUpdate] = useState(true);
   const [edit, setEdit] = useState(false);
-  const [linkText, setLinkText] = useState(["All", "Progress", "Done"]);
+  const [linkText, setLinkText] = useState(["All", "Uncheck", "Check"]);
   const [data, setData] = useState([]);
   const [editable, setEditable] = useState(true);
 
@@ -38,12 +38,12 @@ function PlanDetail() {
         }
       )
       .then((res) => {
-        console.log(res);
-        const fetchData = res.data;
+        // console.log(res);
+        const objKey = Object.keys(res.data)[0];
+        const fetchData = res.data[objKey];
         const todos = {};
-        fetchData.data.forEach((todo) => {
+        fetchData.forEach((todo) => {
           Object.assign(todo, { plan_id: id });
-          console.log(Object.keys(todo).length);
           if (Object.keys(todo).length === 4) {
             setLinkText(["All"]);
             setEditable(false);


### PR DESCRIPTION
# 1. 로그인 로직 수정, 로그아웃 추가
refresh 토큰을 통해서 자동 로그인 되도록 로직을 변경하였습니다. 자동로그인 절차는 다음과 같습니다.

1. 유저가 '/'에 접속한다.
2. refresh 토큰이 있는지 확인하고, 있으면 '/api/token/verify'로 검증한다.
3. 검증 결과 유효한 refresh 토큰이면, '/todo'로 이동한다.

access 토큰이 유효하지않으면, 401 에러가 뜰테니 이를 ErrorHandler 컴포넌트
를 생성해서 처리하도록 했습니다.
ErrorHandler 컴포넌트에서는 error를 props로 받아서 401 에러면 refresh 검증,
access 재발급 후 직전 페이지로 이동하도록 했고, refresh가 유효하지않으면 로그인 화면으로
리다이렉트되도록 했습니다.
현재 서비스 이용 중 토큰 기한이 끝나서 에러가 뜨면 에러 화면만 뜨던 것을
처리하려는 용도로 만들었는데, 이 로직을 모든 axios catch 부분에 다 넣기보다는 아예
컴포넌트로 빼는게 좋을 것 같아서 일단 이렇게 했습니다. 
현재 적용은 Todo에만 했는데 이렇게 해도 괜찮을지 의견주세용

(추가) 자동 로그인하면서 access 토큰도 재발급해주고 '/todo'로 보내도 될 것 같은데, ErrorHandler가 잘 작동하는지 보려고
일단 이렇게 해놨슴당

# 2. PlanSheet UX 향상
PlanSheet가 열렸을 때, 외부를 클릭하면 Sheet가 닫히게 수정했습니다. 
https://github.com/Temzasse/react-modal-sheet
Backdrop에 onTap을 줘야지 외부가 button 태그가 되어서 클릭이 된다더라구요. button이 되면서 생기는 border을 없애기 위해서 styled-components로 감싸서 처리했습니다.

# 3. PlanMarketDetail 변경
현재 플랜 마켓에서 플랜을 구매하는 페이지가 viewtemplate로 쓰이고 있었는데, 이를 PlanMarketDetailOld로 변경했습니다.
url path도 '/planmarket/plan/:planId'로 변경했습니다. 
viewtemplate를 예전에 리팩토링하면서 이미지 하나로 모두 처리하던 것을 수정하려고 했었다가 다른 우선순위가 생겨서
하다 말았었는데 그게 PlanMarketDetail 컴포넌트입니당.
PlanMarketDetailOld는 일단 viewtemplate를 styled-components 이용해서 리팩토링한 컴포넌트입니다. 리팩토링하면서
기획 요청에 따라 footer에 구매 버튼을 추가하였고, 이미 구매한 플랜이면 버튼이 바뀌도록 하였습니다.

# 4. PlanDetail 변경
현재 All, Progress, Done으로 되어있던 탭을 체크 여부로 나누는 All, Uncheck, check로 변경했습니다.
그러면서 fetch 해오는 데이터 형식이 바뀌었는데, 각각 json object key가 다른 바람에 그냥 Object.keys[0]으로 처리했습니다.

PlanDetail 페이지는 등록한 플랜이랑 아닌 플랜이랑 좀 달라서 수정을 해야할 것 같습니다.
등록한 것은 day로 주고, 안한거는 date로 주는 바람에 데이터 가공 로직도 복잡해지는 면도 있고,
등록 안한거는 투두를 체크할 수 없으니까 체크 버튼도 없어야할 것 같기도하고 이거는 기획쪽이랑 얘기해봐야할 것 같아요.