### PR TITLE
로그인 로직 수정, 캘린더에 투두 표시, UX 개선

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -56,7 +56,7 @@
 }
 
 .MuiPickersDay-current {
-  color: #8977F7 !important;
+  color: #7965F4 !important;
 }
 
 .MuiTypography-body2, .MuiTypography-caption {

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import "antd/dist/antd.css";
 import "./App.css";
 import { Route, Routes } from "react-router-dom";
+import RootPage from "./components/login/RootPage.components";
 import LoginPage from "./components/login/LoginPage.components";
 import Onboard1 from "./components/onboard/onboard1.components";
 import Onboard2 from "./components/onboard/onboard2.components";
@@ -24,7 +25,8 @@ function App() {
   return (
     <div className="App">
       <Routes>
-        <Route path="/" element={<LoginPage />} />
+        <Route path="/" element={<RootPage />} />
+        <Route path="/login" element={<LoginPage />} />
         <Route path="/admin" element={<Admin />} />
         <Route path="/login/kakao/:code" element={<KakaoSocial />} />
         <Route path="/auth/google/callback" element={<GoogleSocial />} />

--- a/src/components/globalcomponents/BottomNavBar.components.jsx
+++ b/src/components/globalcomponents/BottomNavBar.components.jsx
@@ -7,8 +7,7 @@ import styled from "styled-components";
 const BottomNavBar = ({ current }) => {
   return (
     <StyledBottomNavBar showLabels>
-      <BottomNavigationAction
-        style={{ paddingTop: 0 }}
+      <NavBarButton
         icon={
           <>
             <img
@@ -26,8 +25,7 @@ const BottomNavBar = ({ current }) => {
         to="/todo"
       />
 
-      <BottomNavigationAction
-        style={{ paddingTop: 0 }}
+      <NavBarButton
         icon={
           <>
             <img
@@ -65,3 +63,7 @@ const StyledBottomNavBar = styled(BottomNavigation)`
   height: 85px !important;
   filter: drop-shadow(0px -3px 4px rgba(0, 0, 0, 0.04));
 `;
+
+const NavBarButton = styled(BottomNavigationAction)`
+  padding: 0px 12px 8px !important;
+`

--- a/src/components/globalcomponents/ErrorHandler.components.jsx
+++ b/src/components/globalcomponents/ErrorHandler.components.jsx
@@ -8,26 +8,20 @@ function ErrorHandler({ error }) {
   useEffect(() => {
     if (error.response.status === 401) {
       axios
-        .post("https://myplanit.link/api/token/verify", {
-          token: localStorage.getItem("refresh"),
+        .post("https://myplanit.link/api/token/refresh", {
+          refresh: localStorage.getItem("refresh"),
         })
         .then((res) => {
-          if (res.status == 200) {
-            axios
-              .post("https://myplanit.link/api/token/refresh", {
-                refresh: localStorage.getItem("refresh"),
-              })
-              .then((res) => {
-                const access = res.data.access;
-                sessionStorage.setItem("access", access);
-                navigate(-1);
-              });
-          }
+          const access = res.data.access;
+          sessionStorage.setItem("access", access);
+          navigate(-1);
         })
         .catch((err) => {
-          localStorage.removeItem("refresh");
-          navigate('/');
-        });
+          if (err.response.status === 401) {
+            localStorage.removeItem("refresh");
+            navigate('/login');
+          }
+        })
     }
   });
 

--- a/src/components/login/LoginPage.components.jsx
+++ b/src/components/login/LoginPage.components.jsx
@@ -1,12 +1,7 @@
-import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import axios from 'axios';
 import constants from "../../constants";
 import * as Styled from "./LoginPage.style";
 
 function LoginPage() {
-  const navigate = useNavigate();
-
   const kakaoLogin = () => {
     window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.REACT_APP_KAKAO_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_KAKAO_REDIRECT_URI}&response_type=code`;
   };
@@ -15,32 +10,9 @@ function LoginPage() {
     window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.REACT_APP_GOOGLE_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_GOOGLE_REDIRECT_URI}&response_type=code&scope=https://www.googleapis.com/auth/userinfo.profile`;
   };
 
-  useEffect(() => {
-    const token = localStorage.getItem("refresh");
-    if (token) {
-      axios.post('https://myplanit.link/api/token/verify', {
-        token,
-      })
-      .then((res) => {
-        if (res.status === 200) {
-          navigate("/todo");
-        }
-      })
-      .catch((err) => {
-        if (err.response.status === 401) {
-          localStorage.removeItem("refresh");
-        }
-      })
-    }
-  }, [])
-  
-
   return (
     <Styled.Container>
-      <Styled.LogoImg
-        src={constants.LOGO}
-        alt="logo"
-      />
+      <Styled.LogoImg src={constants.LOGO} alt="logo" />
       <Styled.LogoText>당신의 목표 가이드, 마이플랜잇</Styled.LogoText>
 
       <Styled.ButtonContainer>

--- a/src/components/login/RootPage.components.jsx
+++ b/src/components/login/RootPage.components.jsx
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+import * as Styled from "./LoginPage.style";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import constants from "../../constants";
+
+function RootPage() {
+  const navigate = useNavigate();
+    
+  useEffect(() => {
+    const refresh = localStorage.getItem("refresh");
+    if (refresh) {
+      axios
+        .post("https://myplanit.link/api/token/refresh", {
+          refresh,
+        })
+        .then((res) => {
+          if (res.status === 200) {
+            const access = res.data.access;
+            sessionStorage.setItem("access", access);
+            navigate("/todo");
+          }
+        })
+        .catch((err) => {
+          if (err.response.status === 401) {
+            localStorage.removeItem("refresh");
+            navigate("/login");
+          }
+        });
+    }
+    else {
+      navigate("/login");
+    }
+  }, []);
+
+  return (
+    <Styled.Container>
+      <Styled.LogoImg src={constants.LOGO} alt="logo" />
+      <Styled.LogoText>당신의 목표 가이드, 마이플랜잇</Styled.LogoText>
+    </Styled.Container>
+  );
+}
+
+export default RootPage;

--- a/src/components/myplan/MyPlan.components.jsx
+++ b/src/components/myplan/MyPlan.components.jsx
@@ -14,6 +14,7 @@ function MyPlan() {
   const [error, setError] = useState(null);
   const [buyLength, setBuyLength] = useState(0);
   const [registerLength, setRegisterLength] = useState(0);
+  const [update, setUpdate] = useState(false);
 
   useEffect(() => {
     const fetchRegisterPlans = async () => {
@@ -64,7 +65,7 @@ function MyPlan() {
     };
 
     fetchBuyPlans();
-  }, []);
+  }, [update]);
 
   if (error) return error;
 
@@ -85,9 +86,9 @@ function MyPlan() {
         registerLength={registerLength}
       />
 
-      {current === "BUY" && <MyPlanContent plans={buyPlans} buy />}
+      {current === "BUY" && <MyPlanContent plans={buyPlans} update={update} setUpdate={setUpdate} buy />}
       {current === "REGISTER" && (
-        <MyPlanContent plans={registerPlans} register />
+        <MyPlanContent plans={registerPlans} update={update} setUpdate={setUpdate} register />
       )}
 
       <BottomNavBar current="TODO" />

--- a/src/components/myplan/MyPlanContent.components.jsx
+++ b/src/components/myplan/MyPlanContent.components.jsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import PlanCard from "./PlanCard.components";
 import PlanSheet from "./PlanSheet.components";
 
-function MyPlanContent({ plans, register, buy }) {
+function MyPlanContent({ plans, register, buy, update, setUpdate }) {
   const [isOpen, setIsOpen] = useState(false);
   const [plan, setPlan] = useState({});
   const [date, setDate] = useState({});
@@ -38,6 +38,8 @@ function MyPlanContent({ plans, register, buy }) {
           writer_name={plan.writer_name}
           date={date}
           register
+          update={update}
+          setUpdate={setUpdate}
         />
       )}
 
@@ -50,6 +52,8 @@ function MyPlanContent({ plans, register, buy }) {
           writer_name={plan.writer_name}
           is_registered={registered}
           buy
+          update={update}
+          setUpdate={setUpdate}
         />
       )}
     </Container>

--- a/src/components/myplan/MyPlanHeader.components.jsx
+++ b/src/components/myplan/MyPlanHeader.components.jsx
@@ -9,7 +9,7 @@ function MyPlanHeader({ current, setCurrent, buyLength, registerLength }) {
   const logout = () => {
     localStorage.removeItem("refresh");
     sessionStorage.removeItem("access");
-    navigate("/");
+    navigate("/login");
   };
 
   return (

--- a/src/components/myplan/MyPlanHeader.components.jsx
+++ b/src/components/myplan/MyPlanHeader.components.jsx
@@ -39,7 +39,7 @@ function MyPlanHeader({ current, setCurrent, buyLength, registerLength }) {
         </Styled.LowerHeader>
       </Styled.Header>
 
-      <Styled.StyledSheet isOpen={open} snapPoints={[200]}>
+      <Styled.StyledSheet isOpen={open} snapPoints={[250]}>
         <Sheet.Container>
           <Sheet.Header />
 

--- a/src/components/myplan/PlanSheet.components.jsx
+++ b/src/components/myplan/PlanSheet.components.jsx
@@ -15,6 +15,8 @@ function PlanSheet({
   buy,
   date,
   is_registered,
+  update,
+  setUpdate
 }) {
   const navigate = useNavigate();
   const accessToken = sessionStorage.getItem("access");
@@ -57,7 +59,8 @@ function PlanSheet({
           },
         }
       ).then((res) => {
-        window.location.reload();
+        setUpdate(!update);
+        setIsOpen(false);
       })
   };
   return (

--- a/src/components/myplan/PlanSheet.components.jsx
+++ b/src/components/myplan/PlanSheet.components.jsx
@@ -22,7 +22,7 @@ function PlanSheet({
   const registerPlan = () => {
     axios
       .post(
-        "https://myplanit.link/myplans/" + planId + "/register",
+        `https://myplanit.link/myplans/${planId}/register`,
         {},
         {
           headers: {
@@ -56,10 +56,9 @@ function PlanSheet({
             Authorization: `Bearer ${accessToken}`,
           },
         }
-      )
-      .then((response) => {
-        navigate("/todo");
-      });
+      ).then((res) => {
+        window.location.reload();
+      })
   };
   return (
     <>

--- a/src/components/planmarket/PlanMarketDetailOld.components.jsx
+++ b/src/components/planmarket/PlanMarketDetailOld.components.jsx
@@ -162,6 +162,7 @@ const BuyButton = styled.button`
   border-radius: 5px;
   color: #ffffff;
   font-family: "PretendardMedium";
+  margin-bottom: 10px;
 
   ${(props) =>
     props.disabled &&

--- a/src/components/todo/Calendar.components.jsx
+++ b/src/components/todo/Calendar.components.jsx
@@ -4,8 +4,9 @@ import { ko } from "date-fns/locale";
 import DateFnsUtils from "@date-io/date-fns";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import styled from "styled-components";
+import { format, isSameDay, isWeekend } from "date-fns";
 
-function Calendar({ selectedDate, setSelectedDate }) {
+function Calendar({ selectedDate, setSelectedDate, days }) {
   const handleDateChange = (date) => {
     sessionStorage.setItem("date", date);
     setSelectedDate(new Date(sessionStorage.getItem("date")));
@@ -25,6 +26,27 @@ function Calendar({ selectedDate, setSelectedDate }) {
           margin="normal"
           value={selectedDate}
           onChange={handleDateChange}
+          renderDay={(day, selectedDay, dayInCurrentMonth, dayComponent) => {
+            const todoExist =
+              dayInCurrentMonth && days.includes(format(day, "yyyy-MM-dd"));
+            return (
+              <div
+                style={{
+                  position: "relative",
+                  display: "flex",
+                  justifyContent: "center",
+                }}
+              >
+                {todoExist && (
+                  <Dot
+                    today={isSameDay(day, new Date())}
+                    isWeekend={isWeekend(day)}
+                  />
+                )}
+                {dayComponent}
+              </div>
+            );
+          }}
         />
       </MuiPickersUtilsProvider>
     </Container>
@@ -44,4 +66,16 @@ const Container = styled.div`
 const StyledDatePicker = styled(DatePicker)`
   width: auto;
   font-family: "PretendardSemiBold";
+`;
+
+const Dot = styled.div`
+  width: 4px;
+  height: 4px;
+  position: absolute;
+  background: black;
+  background: ${(props) => props.isWeekend && "#929292"};
+  background: ${(props) => props.today && "#7965f4"};
+  top: 5px;
+  border-radius: 100%;
+  z-index: 3;
 `;

--- a/src/components/todo/MyTodo.components.jsx
+++ b/src/components/todo/MyTodo.components.jsx
@@ -72,7 +72,7 @@ const TodoCard = styled.div`
   padding: 10px 20px;
   border-radius: 4px;
   width: 327px;
-  height: 52px;
+  min-height: 52px;
   margin-top: 9px;
   display: flex;
   align-items: center;

--- a/src/components/todo/Todo.components.jsx
+++ b/src/components/todo/Todo.components.jsx
@@ -99,6 +99,8 @@ function Todo() {
         current={current}
         setCurrent={setCurrent}
         setDelay={setDelay}
+        updateMy={updateMy}
+        update={update}
       />
 
       {current === "PLAN" && (

--- a/src/components/todo/TodoHeader.components.jsx
+++ b/src/components/todo/TodoHeader.components.jsx
@@ -3,6 +3,8 @@ import { Link } from "react-router-dom";
 import { Button } from "antd";
 import styled from "styled-components";
 import WeekCalendar from "./WeekCalendar.components";
+import { useEffect, useState } from "react";
+import axios from "axios";
 
 function TodoHeader({
   selectedDate,
@@ -12,8 +14,31 @@ function TodoHeader({
   current,
   setCurrent,
   setDelay,
+  updateMy,
+  update,
 }) {
+  const accessToken = sessionStorage.getItem("access");
   const linkText = ["PLAN", "MY"];
+  const [days, setDays] = useState([]);
+
+  const fetchDays = () => {
+    axios
+      .get("https://myplanit.link/todos/allofdate", {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      })
+      .then((res) => {
+        const planDays = res.data.plan_todos.map((item) => item.date);
+        const myPlanDays = res.data.personal_todos.map((item) => item.date);
+        const dayList = [...new Set([...planDays, ...myPlanDays])];
+        setDays(dayList);
+      });
+  };
+
+  useEffect(() => {
+    fetchDays();
+  }, [update, updateMy]);
 
   return (
     <HeaderContainer>
@@ -21,6 +46,7 @@ function TodoHeader({
         <Calendar
           selectedDate={selectedDate}
           setSelectedDate={setSelectedDate}
+          days={days}
         />
         <Link to="../myplan">
           <StyledButton>MY PLAN</StyledButton>
@@ -30,6 +56,7 @@ function TodoHeader({
       <WeekCalendar
         selectedDate={selectedDate}
         setSelectedDate={setSelectedDate}
+        days={days}
       />
 
       <LowerHeader>

--- a/src/components/todo/WeekCalendar.components.jsx
+++ b/src/components/todo/WeekCalendar.components.jsx
@@ -4,19 +4,19 @@ import {
   startOfWeek,
   eachDayOfInterval,
   isSameDay,
-  isSunday,
-  isSaturday,
-  isWeekend
+  isWeekend,
 } from "date-fns";
 import styled from "styled-components";
 
-function WeekCalendar({ selectedDate, setSelectedDate }) {
+function WeekCalendar({ selectedDate, setSelectedDate, days }) {
   const endOfWeek = lastDayOfWeek(selectedDate);
   const firstOfWeek = startOfWeek(selectedDate);
   const weekDays = eachDayOfInterval({
     start: firstOfWeek,
     end: endOfWeek,
   });
+
+  const todoExist = (date) => days.includes(format(date, "yyyy-MM-dd"));
 
   return (
     <Calendar>
@@ -28,6 +28,12 @@ function WeekCalendar({ selectedDate, setSelectedDate }) {
           today={isSameDay(date, new Date())}
           isWeekend={isWeekend(date)}
         >
+          {todoExist(date) && (
+            <Dot
+              isWeekend={isWeekend(date)}
+              today={isSameDay(date, new Date())}
+            />
+          )}
           <span>{format(date, "d")}</span>
         </Day>
       ))}
@@ -51,12 +57,12 @@ const Day = styled.div`
   align-items: center;
   position: relative;
   padding: 5px;
-  width: 30px;
-  height: 30px;
+  width: 36px;
+  height: 36px;
   text-align: center;
   color: black;
-  color: ${props => props.isWeekend && "#929292"};
-  color: ${(props) => (props.today && "#7965F4")};
+  color: ${(props) => props.isWeekend && "#929292"};
+  color: ${(props) => props.today && "#7965F4"};
 
   span {
     font-size: 16px;
@@ -76,9 +82,21 @@ const Day = styled.div`
     left: 0;
     content: "";
     background-color: #e1dcfe;
-    width: 30px;
-    height: 30px;
+    width: 36px;
+    height: 36px;
     border-radius: 100%;
     z-index: 1;
   }`}
+`;
+
+const Dot = styled.div`
+  width: 4px;
+  height: 4px;
+  position: absolute;
+  background: black;
+  background: ${(props) => props.isWeekend && "#929292"};
+  background: ${(props) => props.today && "#7965f4"};
+  top: 5px;
+  border-radius: 100%;
+  z-index: 3;
 `;


### PR DESCRIPTION
# 1. 로그인 로직 수정
기존에 로그인 화면에 들어갔다가 /todo로 이동하는 것 때문에 깜빡이는 현상을 수정하기 위해서 '/'를 로고만 있는 새로운 컴포넌트로 바꾸고, refresh 토큰으로 access 토큰을 받는 과정을 api/token/refresh 하나로 간소화했습니다.
refresh가 유효하지않으면 로그인 화면으로 이동하고, 유효하면 access 토큰을 받은 후 '/todo'로 이동합니다.

# 2. 캘린더에 투두 표시
투두가 있는 날짜에는 점으로 표시가 되도록 기능을 추가했습니다. 이를 위해서 TodoHeader에 fetch하는 과정이 추가되었습니다.

# 3. 투두 삭제 시 /todo로 이동하는 현상 수정
update state를 추가하여
마이플랜에서 투두를 삭제한 후 /todo로 이동하지 않고 데이터를 다시 fetch하고 sheet를 닫도록 수정했습니다. 

# 4. css 수정
1. BottomNavBar의 padding이 Calendar 모달을 열었을 때 변경되는 현상 수정
2. 로그아웃 Sheet 알림의 하단 여백 너비 증가
3. 플랜 구매 페이지 구매 버튼 살짝 위로 위치 조정
4. myTodo 텍스트 줄이 늘어날 수록 height가 증가하도록 수정