### PR TITLE
weekCalendar 로직 수정, planTodo 선택 시 border 수정

### DIFF
--- a/src/components/todo/PlanTodo.components.jsx
+++ b/src/components/todo/PlanTodo.components.jsx
@@ -4,19 +4,12 @@ import axios from "axios";
 import constants from "../../constants";
 import styled from "styled-components";
 
-function PlanTodo({
-  todo,
-  update,
-  setUpdate,
-  edit,
-  delay,
-  setDelay,
-}) {
+function PlanTodo({ todo, update, setUpdate, edit, delay, setDelay }) {
   const navigate = useNavigate();
   const todoName = todo["plan_todo"];
   const isChecked = todo["finish_flag"];
   const selected = delay.includes(todo["id"]);
-  const accessToken = sessionStorage.getItem("access")
+  const accessToken = sessionStorage.getItem("access");
   const checkTodo = async (todo) => {
     axios
       .post(
@@ -58,7 +51,9 @@ function PlanTodo({
           alignItems: "center",
           opacity: isChecked && edit ? "0.4" : 1,
         }}
-        onClick={() => !edit && navigate(`/todo/detail/${todo["plan_todo_id"]}`)}
+        onClick={() =>
+          !edit && navigate(`/todo/detail/${todo["plan_todo_id"]}`)
+        }
       >
         <span style={{ fontFamily: "PretendardMedium" }}>{todoName}</span>
         <DetailIcon src={constants.DETAIL_ICON} />
@@ -75,11 +70,23 @@ const Container = styled.div`
   margin-top: 5px;
   margin-left: 0 !important;
   display: flex;
+  justify-content: center;
   align-items: center;
-  border-radius: 4px;
+
   box-sizing: border-box;
 
-  border: 1.5px solid ${(props) => (props.selected ? "#8977f7" : "transparent")};
+  ${(props) =>
+    props.selected &&
+    `
+      &::before {
+        content: "";
+        border: 1.5px solid #8977f7;
+        border-radius: 4px;
+        width: 300px;
+        height: 40px;
+        position: absolute;
+      }
+    `}
 `;
 
 const StyledCheckbox = styled(Checkbox)`

--- a/src/components/todo/WeekCalendar.components.jsx
+++ b/src/components/todo/WeekCalendar.components.jsx
@@ -5,8 +5,7 @@ import {
   eachDayOfInterval,
   isSameDay,
   isWeekend,
-  nextSunday,
-  previousSaturday
+  addWeeks
 } from "date-fns";
 import styled from "styled-components";
 
@@ -19,8 +18,8 @@ function WeekCalendar({ selectedDate, setSelectedDate, days }) {
   });
 
   const todoExist = (date) => days.includes(format(date, "yyyy-MM-dd"));
-  const nextWeek = () => setSelectedDate(nextSunday(selectedDate));
-  const previousWeek = () => setSelectedDate(previousSaturday(selectedDate));
+  const nextWeek = () => setSelectedDate(addWeeks(selectedDate, 1));
+  const previousWeek = () => setSelectedDate(addWeeks(selectedDate, -1));
 
   return (
     <Calendar>


### PR DESCRIPTION
# 1. weekCalender 로직 수정
weekCalender에서 주차 변경 시 +7일, -7일이 되도록 변경했습니다.
# 2. planTodo 선택시 border 수정
수정 전
![image (1)](https://user-images.githubusercontent.com/63638539/165350664-6acd7726-cc9f-4813-af68-d601bbb32a52.png)
수정 후
![image](https://user-images.githubusercontent.com/63638539/165350769-e1b1bc90-4b67-4745-ab4d-602e4330814e.png)
